### PR TITLE
Fix configs deploy on Fedora (robust WirePlumber detection) + force LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Force LF line endings on files executed or parsed on Linux.
+# Checkouts with core.autocrlf=true otherwise get CRLF working trees,
+# which breaks the installers with errors like: $'\r': command not found
+*.sh       text eol=lf
+*.conf     text eol=lf
+*.rules    text eol=lf
+*.lua      text eol=lf
+*.py       text eol=lf
+*.service  text eol=lf
+*.desktop  text eol=lf
+Makefile   text eol=lf
+*.mk       text eol=lf
+dkms.conf  text eol=lf

--- a/configs/deploy.sh
+++ b/configs/deploy.sh
@@ -21,16 +21,22 @@ fi
 echo "Installing WirePlumber rules..."
 
 # Detect WirePlumber version: 0.5+ uses .conf (JSON-like), 0.4.x uses .lua
+# (patched: ask wireplumber/wpctl directly first; probe ALL package managers with
+#  fall-through instead of elif — a host can have e.g. dpkg installed on Fedora
+#  with no database entry, which previously aborted the script under `set -e`)
 WP_VER=""
-if command -v wpctl &>/dev/null; then
-    # wpctl doesn't have --version, so check the package manager
-    if command -v pacman &>/dev/null; then
-        WP_VER=$(pacman -Q wireplumber 2>/dev/null | awk '{print $2}' | cut -d- -f1)
-    elif command -v dpkg &>/dev/null; then
-        WP_VER=$(dpkg -s wireplumber 2>/dev/null | grep '^Version:' | awk '{print $2}' | cut -d- -f1 | cut -d: -f2)
-    elif command -v rpm &>/dev/null; then
-        WP_VER=$(rpm -q --qf '%{VERSION}' wireplumber 2>/dev/null)
-    fi
+WP_VER=$(wireplumber --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 || true)
+if [ -z "$WP_VER" ]; then
+    WP_VER=$(wpctl --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 || true)
+fi
+if [ -z "$WP_VER" ] && command -v pacman &>/dev/null; then
+    WP_VER=$(pacman -Q wireplumber 2>/dev/null | awk '{print $2}' | cut -d- -f1 || true)
+fi
+if [ -z "$WP_VER" ] && command -v dpkg &>/dev/null; then
+    WP_VER=$(dpkg -s wireplumber 2>/dev/null | grep '^Version:' | awk '{print $2}' | cut -d- -f1 | cut -d: -f2 || true)
+fi
+if [ -z "$WP_VER" ] && command -v rpm &>/dev/null; then
+    WP_VER=$(rpm -q --qf '%{VERSION}' wireplumber 2>/dev/null || true)
 fi
 
 WP_MAJOR=$(echo "$WP_VER" | cut -d. -f1)


### PR DESCRIPTION
## Summary

Two fixes discovered while bringing up an **Apollo x8p (Thunderbolt 3) on Fedora 44** — which, happy to report, **works** (kernel 7.1.4, Secure Boot ON via DKMS-signed module + MOK enrollment; enumerates as `Apollo x8 / UA Apollo PCM` in ALSA/PipeWire, test tone verified). Feel free to bump the x8p from "Needs testing" ✅

### 1. `fix(configs)`: robust WirePlumber version detection (`configs/deploy.sh`)

`deploy.sh` detects the WirePlumber version by probing package managers with an
`elif` chain (`pacman` → `dpkg` → `rpm`). On a Fedora host that happens to have
the `dpkg` **utility** installed (with no Debian database), the `dpkg` branch is
selected, `dpkg -s wireplumber` fails, and under `set -euo pipefail` the failed
pipeline **aborts the whole script**. The installer then reports `configs: fail`
with no detail, and none of the WirePlumber/UCM2/udev configs get deployed.

Fix:
- Ask WirePlumber itself first (`wireplumber --version`, then `wpctl --version`).
- Fall through **all** package-manager probes (no `elif` short-circuit), each
  guarded with `|| true` so a failed probe can't kill the script under `set -e`.

Verified on Fedora 44 / WirePlumber 0.5+: deploy completes and installs the
`.conf`-format rules.

### 2. `chore`: add `.gitattributes` forcing LF on scripts/configs

Checkouts with `core.autocrlf=true` (common on dual-boot machines where git is
also used from Windows) convert the repo's LF files to CRLF in the working tree,
and the installer explodes with:

```
scripts/install.sh: line 11: $'\r': command not found
syntax error near unexpected token $'do\r'
```

Pinning `eol=lf` on `*.sh` / `*.conf` / `*.rules` / `Makefile` / etc. makes the
installer work regardless of the user's autocrlf setting.

## Test environment

- Apollo x8p, Thunderbolt 3 Option Card, Fedora 44, kernel 7.1.4-200, Secure Boot **enabled** (DKMS-signed module + MOK enroll)
- WirePlumber 0.5+ (`.conf` config format branch)
- Full install: deps/build/dkms/init/daemon all OK; audio test passed
