### PR TITLE
fix: detect Apollo x8p by PCI subsystem ID (0x0014)

### DIFF
--- a/driver/ua_apollo.h
+++ b/driver/ua_apollo.h
@@ -36,6 +36,7 @@
 #define UA_SUBSYS_APOLLO_X4_QUAD        0x0011
 #define UA_SUBSYS_APOLLO_SOLO           0x000F
 #define UA_SUBSYS_APOLLO_8P             0x0006
+#define UA_SUBSYS_APOLLO_X8P            0x0014  /* x8p: serial 2008xxxx false-matches "2017"->x8; 6 DSPs, FPGA 0xa241c5ac */
 
 /*
  * UAD2DeviceType enum — reconstructed from CPcieDevice::Name() and

--- a/driver/ua_core.c
+++ b/driver/ua_core.c
@@ -215,6 +215,11 @@ static void ua_detect_capabilities(struct ua_device *ua)
 		case UA_SUBSYS_APOLLO_8P:
 			ua->device_type = UA_DEV_APOLLO_8P;
 			break;
+		case UA_SUBSYS_APOLLO_X8P:
+			/* x8p serial "2008xxxx" false-matches "2017"->x8 in the
+			 * serial table; pin it by subsystem ID (0x0014) instead. */
+			ua->device_type = UA_DEV_APOLLO_X8P;
+			break;
 		case UA_SUBSYS_APOLLO_SOLO:
 			ua->device_type = UA_DEV_APOLLO_SOLO;
 			break;


### PR DESCRIPTION
The x8p's serial contains `2017` at the serial+4 offset, false-matching the x8 prefix — the same ambiguity the code documents for Solo/`2032`/x16D. Adds `UA_SUBSYS_APOLLO_X8P 0x0014` + a switch case in `ua_core.c` (same pattern as the 8P fix). Tested on a physical x8p (TB3, FPGA 0xa241c5ac, 6 DSPs): dmesg now reports **Apollo x8p, subsys 0x0014, 8 preamps**. Note: fixes identification only — the x8p transport still never clocks (tracked in #46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)