### PR TITLE
ci: add PR checks workflow and harden install matrix

### DIFF
--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -1,0 +1,48 @@
+name: Install Matrix Test
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'driver/**'
+      - 'scripts/**'
+      - 'configs/**'
+      - 'tests/docker/**'
+      - '.github/workflows/install-matrix.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'driver/**'
+      - 'scripts/**'
+      - 'configs/**'
+      - 'tests/docker/**'
+      - '.github/workflows/install-matrix.yml'
+
+concurrency:
+  group: install-matrix-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-install:
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: [ubuntu, fedora, debian, arch, opensuse]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build test image
+        run: docker build -t test-${{ matrix.distro }} -f tests/docker/Dockerfile.${{ matrix.distro }} .
+      - name: Install + verify artifacts
+        run: |
+          docker run --rm test-${{ matrix.distro }} bash -c "
+            TEST_BUILD=1 bash scripts/install.sh --skip-init --no-dkms 2>&1 || exit 1;
+            # Verify WirePlumber config deployed
+            ls /etc/wireplumber/wireplumber.conf.d/51-ua-apollo.conf 2>/dev/null || \
+            ls /etc/wireplumber/main.lua.d/51-ua-apollo.lua 2>/dev/null || \
+            { echo 'FAIL: No WirePlumber config'; exit 1; };
+            # Verify UCM2 config deployed
+            ls /usr/share/alsa/ucm2/ua_apollo/ua_apollo.conf || \
+            { echo 'FAIL: No UCM2 config'; exit 1; };
+            echo 'All checks passed'
+          "

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,12 +18,13 @@ jobs:
       - name: Install kernel headers
         run: |
           sudo apt-get update
-          sudo apt-get install -y "linux-headers-$(uname -r)" || sudo apt-get install -y linux-headers-generic
+          sudo apt-get install -y linux-headers-generic
       - name: Build module
         run: |
-          # Fall back to newest installed headers if runner kernel headers unavailable
-          KDIR="/lib/modules/$(uname -r)/build"
-          [ -d "$KDIR" ] || KDIR="$(ls -d /lib/modules/*/build | sort -V | tail -1)"
+          # Build against generic headers, not the runner's Azure kernel —
+          # Azure kernels lack CONFIG_SND, so modpost can't resolve snd_*
+          # symbols. Module is compile-tested only, never loaded in CI.
+          KDIR="$(ls -d /usr/src/linux-headers-*-generic | sort -V | tail -1)"
           make -C driver KDIR="$KDIR"
 
   python-lint:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,65 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+concurrency:
+  group: pr-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  driver-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install kernel headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y "linux-headers-$(uname -r)" || sudo apt-get install -y linux-headers-generic
+      - name: Build module
+        run: |
+          # Fall back to newest installed headers if runner kernel headers unavailable
+          KDIR="/lib/modules/$(uname -r)/build"
+          [ -d "$KDIR" ] || KDIR="$(ls -d /lib/modules/*/build | sort -V | tail -1)"
+          make -C driver KDIR="$KDIR"
+
+  python-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Ruff (errors only) + compile check
+        run: |
+          # E9/F63/F7/F82: syntax errors + real faults only — current tree is
+          # green at this level; do not widen without fixing findings first
+          pipx run ruff check --select E9,F63,F7,F82 mixer-engine tools
+          python -m compileall -q mixer-engine
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Shellcheck
+        run: |
+          sudo apt-get install -y shellcheck
+          find scripts tools configs -name '*.sh' -print0 | xargs -0 shellcheck --severity=error
+
+  console-web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: console-web/package-lock.json
+      - name: Build
+        working-directory: console-web
+        run: |
+          npm ci
+          npm run build

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Shellcheck
         run: |
           sudo apt-get install -y shellcheck
-          find scripts tools configs -name '*.sh' -print0 | xargs -0 shellcheck --severity=error
+          find scripts tools configs tests -name '*.sh' -print0 | xargs -0 shellcheck --severity=error
 
   console-web:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,6 @@ docs-site/
 # Local testbench plans and scripts (not part of project)
 plans/
 tools/testbench/
-tests/
 
 usb-firmware
 driver/.*.cmd

--- a/tests/docker/Dockerfile.arch
+++ b/tests/docker/Dockerfile.arch
@@ -1,0 +1,12 @@
+# NOTE: --platform=linux/amd64 required for Apple Silicon (no arm64 archlinux image).
+# pacman --disable-sandbox works around QEMU user namespace issue under emulation.
+FROM --platform=linux/amd64 archlinux:latest
+RUN pacman -Syu --noconfirm --disable-sandbox && pacman -S --noconfirm --disable-sandbox \
+    base-devel linux-headers gcc make \
+    python python-pip python-websockets python-zeroconf \
+    pipewire pipewire-alsa pipewire-pulse wireplumber alsa-utils \
+    openssh dkms curl sudo \
+    && pacman -Scc --noconfirm
+WORKDIR /opt/open-apollo
+COPY . .
+CMD ["bash", "-c", "TEST_BUILD=1 bash scripts/install.sh --skip-init --no-dkms"]

--- a/tests/docker/Dockerfile.debian
+++ b/tests/docker/Dockerfile.debian
@@ -1,0 +1,11 @@
+FROM debian:trixie
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+    build-essential linux-headers-generic gcc make \
+    python3 python3-pip python3-websockets python3-zeroconf \
+    pipewire wireplumber alsa-utils \
+    openssh-server dkms curl sudo \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /opt/open-apollo
+COPY . .
+CMD ["bash", "-c", "TEST_BUILD=1 bash scripts/install.sh --skip-init --no-dkms"]

--- a/tests/docker/Dockerfile.debian-bookworm
+++ b/tests/docker/Dockerfile.debian-bookworm
@@ -1,0 +1,11 @@
+FROM debian:bookworm
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+    build-essential linux-headers-generic gcc make \
+    python3 python3-pip python3-websockets \
+    pipewire wireplumber alsa-utils \
+    openssh-server dkms curl sudo \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /opt/open-apollo
+COPY . .
+CMD ["bash", "-c", "TEST_BUILD=1 bash scripts/install.sh --skip-init --no-dkms"]

--- a/tests/docker/Dockerfile.debian-bullseye
+++ b/tests/docker/Dockerfile.debian-bullseye
@@ -1,0 +1,13 @@
+FROM debian:bullseye
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+    build-essential linux-headers-generic gcc make \
+    python3 python3-pip \
+    alsa-utils \
+    openssh-server dkms curl sudo \
+    && rm -rf /var/lib/apt/lists/*
+# NOTE: Debian 11 has no pipewire/wireplumber in main repos.
+# Driver build + base config deploy still tested.
+WORKDIR /opt/open-apollo
+COPY . .
+CMD ["bash", "-c", "TEST_BUILD=1 bash scripts/install.sh --skip-init --no-dkms"]

--- a/tests/docker/Dockerfile.fedora
+++ b/tests/docker/Dockerfile.fedora
@@ -1,0 +1,10 @@
+FROM fedora:42
+RUN dnf install -y \
+    gcc make kernel-devel \
+    python3 python3-pip python3-websockets \
+    pipewire wireplumber alsa-utils \
+    openssh-server dkms curl sudo \
+    && dnf clean all
+WORKDIR /opt/open-apollo
+COPY . .
+CMD ["bash", "-c", "TEST_BUILD=1 bash scripts/install.sh --skip-init --no-dkms"]

--- a/tests/docker/Dockerfile.fedora-40
+++ b/tests/docker/Dockerfile.fedora-40
@@ -1,0 +1,10 @@
+FROM fedora:40
+RUN dnf install -y \
+    gcc make kernel-devel \
+    python3 python3-pip python3-websockets \
+    pipewire wireplumber alsa-utils \
+    openssh-server dkms curl sudo \
+    && dnf clean all
+WORKDIR /opt/open-apollo
+COPY . .
+CMD ["bash", "-c", "TEST_BUILD=1 bash scripts/install.sh --skip-init --no-dkms"]

--- a/tests/docker/Dockerfile.fedora-41
+++ b/tests/docker/Dockerfile.fedora-41
@@ -1,0 +1,10 @@
+FROM fedora:41
+RUN dnf install -y \
+    gcc make kernel-devel \
+    python3 python3-pip python3-websockets \
+    pipewire wireplumber alsa-utils \
+    openssh-server dkms curl sudo \
+    && dnf clean all
+WORKDIR /opt/open-apollo
+COPY . .
+CMD ["bash", "-c", "TEST_BUILD=1 bash scripts/install.sh --skip-init --no-dkms"]

--- a/tests/docker/Dockerfile.manjaro
+++ b/tests/docker/Dockerfile.manjaro
@@ -1,0 +1,11 @@
+# Manjaro — Arch-based rolling release with delayed package updates
+FROM --platform=linux/amd64 manjarolinux/base
+RUN pacman -Syu --noconfirm --disable-sandbox && pacman -S --noconfirm --disable-sandbox \
+    base-devel linux-headers gcc make \
+    python python-pip python-websockets python-zeroconf \
+    pipewire pipewire-alsa pipewire-pulse wireplumber alsa-utils \
+    openssh dkms curl sudo \
+    && pacman -Scc --noconfirm
+WORKDIR /opt/open-apollo
+COPY . .
+CMD ["bash", "-c", "TEST_BUILD=1 bash scripts/install.sh --skip-init --no-dkms"]

--- a/tests/docker/Dockerfile.mint
+++ b/tests/docker/Dockerfile.mint
@@ -1,0 +1,12 @@
+# Linux Mint 22 is based on Ubuntu 24.04
+FROM linuxmintd/mint22-amd64
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+    build-essential linux-headers-generic gcc make \
+    python3 python3-pip python3-websockets python3-zeroconf \
+    pipewire wireplumber alsa-utils \
+    openssh-server dkms curl sudo \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /opt/open-apollo
+COPY . .
+CMD ["bash", "-c", "TEST_BUILD=1 bash scripts/install.sh --skip-init --no-dkms"]

--- a/tests/docker/Dockerfile.opensuse
+++ b/tests/docker/Dockerfile.opensuse
@@ -1,0 +1,10 @@
+FROM opensuse/tumbleweed
+RUN zypper install -y \
+    gcc make kernel-devel \
+    python3 python3-pip python3-websockets \
+    pipewire wireplumber alsa-utils \
+    openssh-server dkms curl sudo \
+    && zypper clean -a
+WORKDIR /opt/open-apollo
+COPY . .
+CMD ["bash", "-c", "TEST_BUILD=1 bash scripts/install.sh --skip-init --no-dkms"]

--- a/tests/docker/Dockerfile.popos
+++ b/tests/docker/Dockerfile.popos
@@ -1,0 +1,14 @@
+# Pop!_OS 22.04 LTS (System76) — Ubuntu 22.04 base with newer kernel
+# No official Docker image; use Ubuntu 24.04 with Pop repos would be fragile.
+# Use Ubuntu 24.04 as proxy — same kernel/packages as Pop 24.04.
+FROM --platform=linux/amd64 ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+    build-essential linux-headers-generic gcc make \
+    python3 python3-pip python3-websockets python3-zeroconf \
+    pipewire wireplumber alsa-utils \
+    openssh-server dkms curl sudo \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /opt/open-apollo
+COPY . .
+CMD ["bash", "-c", "TEST_BUILD=1 bash scripts/install.sh --skip-init --no-dkms"]

--- a/tests/docker/Dockerfile.ubuntu
+++ b/tests/docker/Dockerfile.ubuntu
@@ -1,0 +1,11 @@
+FROM ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+    build-essential linux-headers-generic gcc make \
+    python3 python3-pip python3-websockets python3-zeroconf \
+    pipewire wireplumber alsa-utils \
+    openssh-server dkms curl sudo \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /opt/open-apollo
+COPY . .
+CMD ["bash", "-c", "TEST_BUILD=1 bash scripts/install.sh --skip-init --no-dkms"]

--- a/tests/docker/Dockerfile.ubuntu-20.04
+++ b/tests/docker/Dockerfile.ubuntu-20.04
@@ -1,0 +1,13 @@
+FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+    build-essential linux-headers-generic gcc make \
+    python3 python3-pip \
+    alsa-utils \
+    openssh-server dkms curl sudo \
+    && rm -rf /var/lib/apt/lists/*
+# NOTE: Ubuntu 20.04 has no pipewire/wireplumber packages in main repos.
+# Driver build + base config deploy still tested.
+WORKDIR /opt/open-apollo
+COPY . .
+CMD ["bash", "-c", "TEST_BUILD=1 bash scripts/install.sh --skip-init --no-dkms"]

--- a/tests/docker/Dockerfile.ubuntu-22.04
+++ b/tests/docker/Dockerfile.ubuntu-22.04
@@ -1,0 +1,11 @@
+FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+    build-essential linux-headers-generic gcc make \
+    python3 python3-pip python3-websockets \
+    pipewire wireplumber alsa-utils \
+    openssh-server dkms curl sudo \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /opt/open-apollo
+COPY . .
+CMD ["bash", "-c", "TEST_BUILD=1 bash scripts/install.sh --skip-init --no-dkms"]

--- a/tests/test-install-matrix.sh
+++ b/tests/test-install-matrix.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# test-install-matrix.sh — Test install script across all supported distros
+# Usage: ./tests/test-install-matrix.sh [distro1 distro2 ...]
+# Without args, tests all distros.
+# Requires: Docker, bash 4+ (macOS: brew install bash)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DISTROS=(ubuntu ubuntu-22.04 ubuntu-20.04 fedora fedora-41 fedora-40 debian debian-bookworm debian-bullseye arch opensuse)
+if [ $# -gt 0 ]; then
+    DISTROS=("$@")
+fi
+
+declare -A RESULTS
+PASS=0
+FAIL=0
+
+echo "============================================"
+echo " Open Apollo — Install Matrix Test"
+echo "============================================"
+echo ""
+
+for distro in "${DISTROS[@]}"; do
+    DOCKERFILE="$SCRIPT_DIR/docker/Dockerfile.$distro"
+    IMAGE="open-apollo-test:$distro"
+
+    if [ ! -f "$DOCKERFILE" ]; then
+        echo "[$distro] SKIP — no Dockerfile"
+        RESULTS[$distro]="SKIP"
+        continue
+    fi
+
+    echo "[$distro] Building image..."
+    BUILD_LOG=$(mktemp)
+    if ! docker build -t "$IMAGE" -f "$DOCKERFILE" "$REPO_DIR" >"$BUILD_LOG" 2>&1; then
+        echo "[$distro] FAIL — Docker build failed"
+        tail -20 "$BUILD_LOG"
+        rm -f "$BUILD_LOG"
+        RESULTS[$distro]="FAIL (build image)"
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+    rm -f "$BUILD_LOG"
+
+    echo "[$distro] Running install + verification..."
+    OUTPUT=$(docker run --rm "$IMAGE" bash -c "
+        TEST_BUILD=1 bash scripts/install.sh --skip-init --no-dkms 2>&1
+        RC=\$?
+        echo '---VERIFY---'
+        echo \"RC=\$RC\"
+        echo \"DISTRO=\$(. /etc/os-release && echo \$ID)\"
+        ls /etc/wireplumber/wireplumber.conf.d/51-ua-apollo.conf 2>/dev/null && echo 'WP_CONF=0.5'
+        ls /etc/wireplumber/main.lua.d/51-ua-apollo.lua 2>/dev/null && echo 'WP_CONF=0.4'
+        ls /usr/share/alsa/ucm2/ua_apollo/ua_apollo.conf 2>/dev/null && echo 'UCM2=yes' || echo 'UCM2=no'
+        ls /usr/local/bin/apollo-setup-io 2>/dev/null && echo 'SETUP_IO=yes' || echo 'SETUP_IO=no'
+        find /opt/open-apollo/driver -name 'ua_apollo.ko' 2>/dev/null | head -1 | grep -q . && echo 'KO_BUILT=yes' || echo 'KO_BUILT=no'
+    " 2>&1)
+
+    VERIFY=$(echo "$OUTPUT" | sed -n '/---VERIFY---/,$p')
+
+    # Extract values portably (no grep -P needed)
+    extract_val() { echo "$VERIFY" | grep "^$1=" | head -1 | cut -d= -f2; }
+    INSTALL_RC=$(extract_val RC)
+    INSTALL_RC=${INSTALL_RC:-999}
+    WP_CONF=$(extract_val WP_CONF)
+    WP_CONF=${WP_CONF:-none}
+    UCM2=$(extract_val UCM2)
+    UCM2=${UCM2:-?}
+    SETUP_IO=$(extract_val SETUP_IO)
+    SETUP_IO=${SETUP_IO:-?}
+    KO_BUILT=$(extract_val KO_BUILT)
+    KO_BUILT=${KO_BUILT:-?}
+
+    if [ "$INSTALL_RC" = "0" ] || echo "$OUTPUT" | grep -q "Installation complete"; then
+        echo "[$distro] PASS  (wp=$WP_CONF ucm2=$UCM2 setup_io=$SETUP_IO ko=$KO_BUILT)"
+        RESULTS[$distro]="PASS (wp=$WP_CONF ucm2=$UCM2 setup_io=$SETUP_IO ko=$KO_BUILT)"
+        PASS=$((PASS + 1))
+    else
+        echo "[$distro] FAIL  (exit=$INSTALL_RC)"
+        echo "$OUTPUT" | grep -v -F -e '---VERIFY---' | tail -15
+        RESULTS[$distro]="FAIL (exit=$INSTALL_RC)"
+        FAIL=$((FAIL + 1))
+    fi
+    echo ""
+done
+
+# Summary
+echo "============================================"
+echo " RESULTS"
+echo "============================================"
+for distro in "${DISTROS[@]}"; do
+    printf "  %-12s %s\n" "$distro" "${RESULTS[$distro]:-SKIP}"
+done
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+echo "============================================"
+
+[ $FAIL -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- Adds `pr-checks.yml`: 4 fast PR jobs — driver compile, ruff + compileall, shellcheck across all scripts, console-web build
- Adds `install-matrix.yml`: path-filtered on `driver/`, `scripts/`, `configs/`, `tests-docker/` (including its own workflow file), with concurrency cancellation and a merged install+verify container run

This PR itself exercises both workflows: `pr-checks` runs on every PR, and `install-matrix` triggers because its own workflow file falls within its path filter.

## Test plan
- [ ] Confirm all 4 `pr-checks` jobs pass
- [ ] Confirm `install-matrix` triggers and passes (install + verify)