### PR TITLE
Fix: stop overwriting monitor-core setting[2] during USB init (breaks front panel knob)

### DIFF
--- a/tools/usb-dsp-init.py
+++ b/tools/usb-dsp-init.py
@@ -213,12 +213,12 @@ def main():
         # EP6 drain stops when the script exits (daemon thread)
         usb.util.release_interface(dev, 0)
 
-    # Step 3: Set monitor level to -12 dB
-    if set_monitor_level(dev, -12):
-        print("Monitor: -12 dB")
-    else:
-        print("Monitor level set failed (non-fatal)")
-
+    # NOTE: deliberately NOT calling set_monitor_level() here.
+    # setting[2] (monitor core) holds volume/mute/source/dim state that the
+    # ARM MCU needs for the front panel knob and buttons to work. Writing it
+    # with a non-zero mask during init overwrites the firmware's own
+    # defaults and breaks physical knob control — see
+    # docs/register-map/page.md and docs/initialization/page.md.
     print("Ready")
 
     if daemon_mode:

--- a/tools/usb-full-init.py
+++ b/tools/usb-full-init.py
@@ -182,14 +182,11 @@ print(f"Clock: {freq} Hz")
 
 usb.util.release_interface(dev, 0)
 
-# Step 3: Set monitor level to -12dB via vendor ctrl (no interface claim needed)
-# Use high sequence counter (100) so FPGA processes it — the full init
-# leaves the internal counter at ~38, so seq=7 gets ignored.
-raw = int(192 + (-12) * 2)  # 0xa8
-mask_buf = bytearray(128)
-struct.pack_into("<I", mask_buf, 16, (0x00FF << 16) | raw)
-dev.ctrl_transfer(0x41, 0x03, 0x062D, 0, bytes(mask_buf), timeout=1000)
-dev.ctrl_transfer(0x41, 0x03, 0x0602, 0, struct.pack("<I", 100), timeout=1000)
-print("Monitor: -12 dB")
+# NOTE: deliberately NOT writing setting[2] (monitor core) here.
+# It holds volume/mute/source/dim state that the ARM MCU needs for the
+# front panel knob and buttons to work. Writing it with a non-zero mask
+# during init overwrites the firmware's own defaults and breaks physical
+# knob control — see docs/register-map/page.md and
+# docs/initialization/page.md.
 
 print("Ready — run 'sudo modprobe snd_usb_audio' to get ALSA card")


### PR DESCRIPTION
## Problem

`usb-dsp-init.py` and `usb-full-init.py` both unconditionally write a
default -12dB value to `setting[2]` (monitor core) at the end of init,
using a non-zero mask (`0x00FF`):

```python
raw = int(192 + (-12) * 2)
mask_buf = bytearray(128)
struct.pack_into("<I", mask_buf, 16, (0x00FF << 16) | raw)
dev.ctrl_transfer(0x41, 0x03, 0x062D, 0, bytes(mask_buf), timeout=1000)
```

Per this project's own documented protocol
(`docs/register-map/page.md`, `docs/initialization/page.md`),
`setting[2]` holds volume/mute/source/dim state that the ARM MCU
depends on for the front panel knob and buttons:

> `setting[2]` (monitor core) must NOT be overwritten during driver
> init. It contains volume, mute, source, and dim state that the ARM
> MCU needs for standalone operation after the host disconnects... A
> Linux driver must follow the same convention — only write mixer
> settings with non-zero masks for fields that have been explicitly
> set by the host.

Both init scripts violate this rule at every boot / hotplug.

## Impact

On an AMD USB3 xHCI controller (Ryzen 7000-series desktop, Ubuntu
26.04, kernel 7.0), after a normal `install-usb.sh` install, turning
the physical monitor knob caused the device to stop responding at the
USB level:

```
usb 2-3.2: 3:0: usb_set_interface failed (-110)
usb 2-3.2: cannot submit urb 0, error -2: endpoint not enabled
```

The failure spread to sibling ports on the same xHCI controller (a
USB webcam and an unrelated hub on the same bus also started failing
descriptor reads) and the desktop compositor became unresponsive.
Recovery required a full reboot — unplugging just the Apollo did not
clear it, since other devices on the same controller kept failing.

After removing the `setting[2]` write from both scripts (this PR), the
same knob operations (many clockwise/counterclockwise turns, plus the
push-button) produced no instability over repeated testing, across a
cold boot and a warm re-init.

## What this PR does *not* fix

The knob is now safe to touch, but it does not yet change the actual
monitor output level — nothing in the current USB stack listens for
the ARM MCU's readback of a physical knob turn and mirrors it back
into `setting[2]`. That's a separate, harder reverse-engineering task
(see the issue I'm filing alongside this PR). This PR only removes the
crash/corruption, it doesn't add knob→volume functionality.

## Testing

- Fresh `install-usb.sh` install on Ubuntu 26.04 / kernel 7.0.0-28-generic
  / AMD 800-series xHCI, Apollo Solo USB
- Confirmed ALSA card + PipeWire virtual I/O + mixer settings (gain,
  48V, mute via vendor request 0x03) all continue to work identically
  with the write removed
- Confirmed physical knob (turn + press) no longer triggers USB
  instability, across a cold power-cycle of the device and a plain
  reboot