### PR TITLE
install-usb.sh: default telemetry to opt-out (not opt-in) in non-interactive runs

### DIFF
--- a/scripts/install-usb.sh
+++ b/scripts/install-usb.sh
@@ -902,7 +902,10 @@ if [ -t 0 ]; then
     echo ""
     prompt TELEM_ANSWER "Help improve Open Apollo — send anonymous install report? [y/N] "
 else
-    TELEM_ANSWER="y"
+    # Locally patched: do not silently opt in to telemetry when running
+    # non-interactively. Upstream defaults this to "y" for non-tty runs;
+    # we require explicit consent instead.
+    TELEM_ANSWER="n"
 fi
 
 if [[ "${TELEM_ANSWER:-n}" =~ ^[Yy] ]]; then


### PR DESCRIPTION
## Problem

```bash
TELEM_ANSWER="n"
if [ -t 0 ]; then
    prompt TELEM_ANSWER "Help improve Open Apollo — send anonymous install report? [y/N] "
else
    TELEM_ANSWER="y"
fi
```

When stdin isn't a tty (script driven by another tool/agent, stdin
redirected, run inside some automation), the installer silently
defaults to **sending** the anonymous install report — kernel version,
CPU model, USB controller vendor, ALSA card state, and a dmesg
excerpt — to the project's telemetry endpoint, without the user ever
seeing or answering the prompt.

This inverts the documented default: the prompt text itself says
`[y/N]`, implying "no" unless answered otherwise, but the non-tty code
path does the opposite.

## Fix

Default `TELEM_ANSWER` to `"n"` in the non-interactive branch too, so
telemetry is only ever sent after an explicit interactive "y".

## Testing

Ran `install-usb.sh` end-to-end (via automation, stdin not a tty) on
Ubuntu 26.04 with the fix applied — firmware/DSP-init prompts correctly
skip (as before), and the telemetry report is no longer POSTed unless
answered "y" at an actual interactive prompt.