### PR TITLE
Use pro-audio PipeWire profile instead of surround-2.1 fallback for Apollo Solo USB

### DIFF
--- a/configs/pipewire/setup-apollo-solo-usb.sh
+++ b/configs/pipewire/setup-apollo-solo-usb.sh
@@ -34,11 +34,28 @@ for obj in json.load(sys.stdin):
 [ -z "$DEVICE_ID" ] && { log "Apollo Solo USB not found in PipeWire"; exit 1; }
 log "Device ID: $DEVICE_ID"
 
-# Use analog surround 2.1 profile (pro-audio has PipeWire capture start bug)
-# Profile 1 = analog-surround-21 output + input (3ch: FL, FR, LFE)
-wpctl set-profile "$DEVICE_ID" 1 2>/dev/null || true
+# Set the pro-audio profile — gives the real 10ch capture / 6ch playback
+# with proper AUX0-9 channel naming. (An earlier version of this script
+# avoided pro-audio for a suspected "capture start bug" and fell back to
+# a 3-channel analog-surround-2.1 profile instead — that fallback doesn't
+# carry mic signal at all on this device and was never actually needed;
+# pro-audio works. Looked up by name, not a hardcoded index: ACP assigns
+# pro-audio a different index per device depending on how many surround
+# permutation profiles it also generates.)
+PROFILE_INDEX=$(pw-dump 2>/dev/null | python3 -c "
+import json, sys
+for obj in json.load(sys.stdin):
+    if obj.get('id') != $DEVICE_ID: continue
+    for p in obj.get('info', {}).get('params', {}).get('EnumProfile', []):
+        if p.get('name') == 'pro-audio':
+            print(p['index']); break
+" 2>/dev/null || true)
+
+[ -z "$PROFILE_INDEX" ] && { log "pro-audio profile not found on device $DEVICE_ID"; exit 1; }
+
+wpctl set-profile "$DEVICE_ID" "$PROFILE_INDEX" 2>/dev/null || true
 sleep 1
-log "Analog surround 2.1 profile set"
+log "pro-audio profile set (index $PROFILE_INDEX)"
 
 # Discover node names
 eval "$(pw-dump 2>/dev/null | python3 -c "
@@ -67,14 +84,14 @@ cat > "$CONF_FILE" << CONF
 context.modules = [
 
     # ═══════ CAPTURE SOURCES (Apollo → PipeWire) ═══════
-    # Analog surround 2.1: FL=Mic1, FR=Mic2, LFE=?
+    # pro-audio capture channels are named AUX0-AUX9: AUX0=Mic1, AUX1=Mic2
 
     # Mic/Instrument 1 (mono)
     { name = libpipewire-module-loopback
         args = {
             node.description = "Apollo Mic 1"
             capture.props = {
-                audio.position    = [ FL ]
+                audio.position    = [ AUX0 ]
                 stream.dont-remix = true
                 node.target       = "$INPUT_NODE"
                 node.passive      = true
@@ -92,7 +109,7 @@ context.modules = [
         args = {
             node.description = "Apollo Mic 2"
             capture.props = {
-                audio.position    = [ FR ]
+                audio.position    = [ AUX1 ]
                 stream.dont-remix = true
                 node.target       = "$INPUT_NODE"
                 node.passive      = true
@@ -110,7 +127,7 @@ context.modules = [
         args = {
             node.description = "Apollo Mic 1+2"
             capture.props = {
-                audio.position    = [ FL FR ]
+                audio.position    = [ AUX0 AUX1 ]
                 stream.dont-remix = true
                 node.target       = "$INPUT_NODE"
                 node.passive      = true
@@ -124,7 +141,7 @@ context.modules = [
     }
 
     # ═══════ PLAYBACK SINKS (PipeWire → Apollo) ═══════
-    # Analog surround 2.1: FL=MonL, FR=MonR, LFE=?
+    # pro-audio playback channels are named AUX0-AUX5: AUX0=Mon L, AUX1=Mon R
 
     # Monitor L/R (main speakers)
     { name = libpipewire-module-loopback
@@ -137,7 +154,7 @@ context.modules = [
             }
             playback.props = {
                 node.target       = "$OUTPUT_NODE"
-                audio.position    = [ FL FR ]
+                audio.position    = [ AUX0 AUX1 ]
                 stream.dont-remix = true
             }
         }


### PR DESCRIPTION
## Problem

`configs/pipewire/setup-apollo-solo-usb.sh` deliberately avoids the `pro-audio` PipeWire profile, citing a "PipeWire capture start bug", and falls back to `analog-surround-21` (a 3-channel profile: FL/FR/LFE).

On my system (Ubuntu 26.04, PipeWire 1.6.2, Apollo Solo USB, AMD Ryzen desktop) I couldn't get any mic signal through the generated loopback devices. Traced it to this profile choice:

- `analog-surround-21` only exposes 3 channels with generic `FL`/`FR`/`LFE` positions — these don't correspond to the documented `AUX0=Mic1, AUX1=Mic2` capture mapping (see the script's own header comment). Verified with `pw-record` + `ffmpeg -af volumedetect`: every channel sat at the digital silence floor (**-91dB**) regardless of what was going into the mic.
- Switching to `pro-audio` (`wpctl set-profile <id> <pro-audio-index>`) gives the real 10ch capture / 6ch playback with channels correctly named `AUX0`...`AUX9` (confirmed via `pw-cli info` on the resulting node — `audio.position = "[ AUX0, AUX1, ..., AUX9 ]"`). With this profile, `AUX0` showed live mic signal immediately (**-26dB mean / -6dB peak** while talking, vs. -91dB floor).

I don't know what the original "capture start bug" was or whether it's PipeWire-version-specific, but it didn't reproduce on 1.6.2 — pro-audio started and streamed capture with no issues across repeated tests (including through a several profile switches, full DSP re-inits, and reboots).

## Fix

- Look up the `pro-audio` profile **by name** from `EnumProfile` instead of a hardcoded index. The previous code assumed index `1`, copied from the PCIe/Thunderbolt sibling script (`setup-apollo-io.sh`) where `1` happens to be `pro-audio` — but on the USB variant, ACP generates a long list of surround-permutation profiles first, so `pro-audio` ends up at a much higher index (30 on my system). A hardcoded index isn't portable across devices/ACP versions either way.
- Updated the loopback `capture.props`/`playback.props` `audio.position` fields to use the pro-audio profile's real channel names (`AUX0`, `AUX1`, ...) instead of the guessed `FL`/`FR`/`LFE` positions that were never correct for this profile's channel layout.

If there's a reason pro-audio was avoided on some other PipeWire version/setup that I'm not hitting, happy to add a fallback path — but as-is, the surround-2.1 profile doesn't carry mic signal at all on my setup, so pro-audio is strictly an improvement for me.

Tested on Apollo Solo USB, Ubuntu 26.04, kernel 7.0.0-28-generic, PipeWire 1.6.2, AMD Ryzen desktop.