### PR TITLE
feat(tools): read the IO descriptor tables over the READ_REG ioctl

### DIFF
--- a/tools/read-io-descriptors.py
+++ b/tools/read-io-descriptors.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+read-io-descriptors.py — dump the Apollo IO descriptor tables.
+
+Firmware populates two 72-word regions after connect: the input IO descriptor
+at 0xC1A4 and the output one at 0xC2C4.  They are the DMA channel order — the
+data ua_get_routing_config() needs, and what it currently lacks for anything
+other than the x4.
+
+Read-only.  Uses the driver's READ_REG ioctl, which is bounds-checked and
+issues no writes, so this needs no rebuild, no module reload and no debugfs
+(the last matters: with Secure Boot on, the kernel is in integrity lockdown
+and /sys/kernel/debug is refused even to root).
+
+  python3 tools/read-io-descriptors.py
+  python3 tools/read-io-descriptors.py --json > x8p-io-desc.json
+
+The driver creates /dev/ua_apollo0 world-accessible, so this needs no root on
+a default install; prefix with sudo only if the node has been tightened.
+
+Layout, as observed on an Apollo x8p (device_type 0x20, FPGA 0xa241c5ac):
+
+  w0        version, 1
+  w1        capacity, 70 entries
+  w2        0xffffffff
+  w3        channel count  (input block)
+  w4        channel count  (output block)
+  w5        flags, 2 on input / 0 on output
+  w6..      u16 channel IDs in DMA order, low half-word first
+            0x00ff pads the unused tail
+
+The channel ID high byte is a group and the low byte a 1-based index within
+it, so 0x0403 is ADAT 3.  Group names below are those the device reports in
+its own routing table (macOS SEL171); groups seen in the descriptor but absent
+from that table are left unnamed rather than guessed at.
+"""
+import argparse
+import fcntl
+import json
+import struct
+import sys
+
+DEV = "/dev/ua_apollo0"
+
+UA_IOCTL_MAGIC = ord('U')
+
+
+def _IOC(direction, typ, nr, size):
+    return (direction << 30) | (size << 16) | (typ << 8) | nr
+
+
+# _IOWR('U', 0x10, struct ua_reg_io) — two u32, offset + value
+UA_IOCTL_READ_REG = _IOC(3, UA_IOCTL_MAGIC, 0x10, 8)
+
+# Register offsets from driver/ua_apollo.h
+UA_REG_IN_NAMES_BASE = 0xC1A4
+UA_REG_OUT_NAMES_BASE = 0xC2C4
+UA_IO_DESC_WORDS = 72
+
+PAD = 0x00FF          # unused-entry marker
+ENTRY_START_WORD = 6  # channel IDs begin here
+
+# Word holding the channel count differs per direction; this is why the driver
+# logs in_buf[3] but out_buf[4].
+COUNT_WORD = {"input": 3, "output": 4}
+
+# Group -> (label, style).  Styles reproduce the naming the device itself
+# reports in its routing table, so output here can be matched against it:
+#   "plain"  -> "ADAT 3"            index used directly
+#   "pair"   -> "MON L" / "MON R"   a single stereo pair
+#   "pairs"  -> "AUX1 L", "AUX2 R"  numbered stereo pairs
+GROUPS = {
+    0x00: ("MIC/LINE/HIZ", "plain"),
+    0x01: ("MIC/LINE", "plain"),
+    0x02: ("AUX", "pairs"),
+    0x03: ("LINE", "plain"),
+    0x04: ("ADAT", "plain"),
+    0x07: ("VIRTUAL", "plain"),
+    0x09: ("MON", "pair"),
+    0x0A: ("CUE", "pairs"),
+    0x0B: ("TALKBACK", "plain"),
+}
+
+
+def read_reg(fd, offset):
+    payload = struct.pack("II", offset, 0)
+    result = fcntl.ioctl(fd, UA_IOCTL_READ_REG, payload)
+    return struct.unpack("II", result)[1]
+
+
+def read_block(fd, base):
+    return [read_reg(fd, base + i * 4) for i in range(UA_IO_DESC_WORDS)]
+
+
+def channel_ids(words, count):
+    raw = struct.pack("<%dI" % len(words), *words)
+    return list(struct.unpack_from("<%dH" % count, raw,
+                                   ENTRY_START_WORD * 4))
+
+
+def describe(cid):
+    group, index = cid >> 8, cid & 0xFF
+    entry = GROUPS.get(group)
+    if entry is None:
+        return "group 0x%02x index %d" % (group, index)
+
+    label, style = entry
+    if style == "pair":
+        return "%s %s" % (label, "L" if index % 2 else "R")
+    if style == "pairs":
+        return "%s%d %s" % (label, (index + 1) // 2, "L" if index % 2 else "R")
+    return "%s %d" % (label, index)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--device", default=DEV, help="device node (default: %s)" % DEV)
+    ap.add_argument("--json", action="store_true",
+                    help="emit raw words and decoded IDs as JSON")
+    args = ap.parse_args()
+
+    try:
+        fd = open(args.device, "rb", buffering=0)
+    except PermissionError:
+        sys.exit("%s: permission denied — run with sudo" % args.device)
+    except FileNotFoundError:
+        sys.exit("%s not found — is the Apollo powered on and ua_apollo loaded?"
+                 % args.device)
+
+    out = {}
+    with fd:
+        for direction, base in (("input", UA_REG_IN_NAMES_BASE),
+                                ("output", UA_REG_OUT_NAMES_BASE)):
+            words = read_block(fd, base)
+            count = words[COUNT_WORD[direction]]
+
+            if count > words[1]:
+                print("warning: %s count %d exceeds capacity %d — "
+                      "layout may differ on this model"
+                      % (direction, count, words[1]), file=sys.stderr)
+                count = min(count, UA_IO_DESC_WORDS * 2 - ENTRY_START_WORD * 2)
+
+            ids = channel_ids(words, count)
+            out[direction] = {
+                "base": base,
+                "version": words[0],
+                "capacity": words[1],
+                "count": count,
+                "words": words,
+                "channel_ids": ids,
+            }
+
+            if args.json:
+                continue
+
+            print("=== %s IO descriptor @ 0x%04X — version %d, %d of %d entries ==="
+                  % (direction, base, words[0], count, words[1]))
+            for i, cid in enumerate(ids):
+                if cid == PAD:
+                    continue
+                print("  dma[%2d] -> 0x%04x  %s" % (i, cid, describe(cid)))
+            print()
+
+    if args.json:
+        json.dump(out, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes the last blocking item on #52: `ua_get_routing_config()` returns NULL for anything but the x4, so on an x8p the IO descriptors are never written and channel order is whatever the FPGA defaults to. This adds the tool that reads the data needed to fix that.

## What the descriptors are

Firmware populates the input descriptor at `0xC1A4` and the output one at `0xC2C4` after connect. Both are a `u16` array of channel IDs in DMA order starting at word 6, with the entry count in word 3 for input and word 4 for output — which is why the connect handshake in `ua_audio.c` logs `in_buf[3]` but `out_buf[4]`. `0x00ff` pads the unused tail. The ID high byte is a group and the low byte a 1-based index, so `0x0403` is ADAT 3.

Header on both: `w0` version 1, `w1` capacity 70, `w2` `0xffffffff`.

Full decoded tables for the x8p are in [#52](https://github.com/rolotrealanis98/open-apollo/issues/52) rather than repeated here.

## Why a tool and not a driver change

I first wrote this as a driver patch that hex-dumped the buffers the connect handshake already reads, behind `print_hex_dump_debug()`. Then I noticed the shipping driver already has a bounds-checked, read-only `READ_REG` ioctl that gets the same data with no rebuild, no module reload, no signing, and no root on a default install — `/dev/ua_apollo0` is `0666`. The tool strictly dominates, so the driver change is dropped.

The debugfs point matters more than it looks: with Secure Boot on, the kernel runs in integrity lockdown and `/sys/kernel/debug` is refused **even to root** (`Lockdown: debugfs access is restricted`). Since DKMS modules have to be MOK-signed to load at all, Secure Boot is the normal case for this driver — so anything routed through `dynamic_debug/control` would be unusable for most users. This tool avoids debugfs entirely.

## Naming

Group names reproduce what the device reports in its own routing table (macOS SEL171), including stereo pairing — `MON L/R`, `AUX1 L` … `AUX2 R`, `CUE1 L` … `CUE4 R` — so output can be diffed against a capture directly. An earlier revision printed `MON 1` / `AUX 3`, which made that comparison impossible; fixed.

Two groups appear in the descriptor but not in SEL171 (`0x05`, a stereo pair in both directions; `0x0c`, sixteen outputs). Those print as raw group and index rather than a guess.

## Verification

Run against a live Apollo x8p — device_type `0x20`, FPGA `0xa241c5ac`, kernel 7.1.5-201.fc44:

- 34 input and 52 output entries decode cleanly, no padding misread
- `--json` output parses, counts match the decoded ID list in both directions
- `dma[0..7]` mapping to preamps 1–8 independently reproduces a signal-injection test on the same unit, so two unrelated methods agree on input ordering
- Runs unprivileged; the permission and missing-node paths both give a usable message

Read-only throughout: `ua_ioctl_read_reg()` bounds-checks the offset, requires 4-byte alignment, and issues no writes. Nothing was rebuilt, reloaded, or signed to produce any of the above.

## The descriptor is not the stream layout

Worth stating explicitly, because I got this wrong at first and it is an easy trap: the 34/52 entry counts are **routing endpoints, not DMA channels**. The stream carries a 26-channel subset in each direction, and `ua_audio.c` pinning the x8p at 26/26 is correct.

The subset falls on exact group boundaries:

- **input** entries 0-25 = 8 analog + 8 ADAT + 2 (`0x05`) + 8 VIRTUAL = 26; entries 26-33 are MON, AUX and TALKBACK, which are mixer returns rather than capture streams
- **output** entries 2-27, skipping MON L/R = 8 LINE + 8 ADAT + 2 (`0x05`) + 8 VIRTUAL = 26; entries 28-51 are CUE sends and the sixteen `0x0c`

`AX_PLAY_CH`/`AX_REC_CH` are no help in deciding this either way — the driver writes them from its own table, so reading them back is circular.

This also makes `0x05` fairly clearly S/PDIF: two channels, in both directions, positioned exactly between ADAT and VIRTUAL. Not named in the tool, since it is inference rather than something the device told us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

