### PR TITLE
feat(contribute): real DTrace probes for the macOS selector capture

### DIFF
--- a/tools/contribute/macos/WHAT-THIS-DOES.md
+++ b/tools/contribute/macos/WHAT-THIS-DOES.md
@@ -44,30 +44,63 @@ its mixer software:
 ## What probes are used?
 
 The DTrace probes target the `IOConnectCallStructMethod` function, which is
-the standard macOS API for communicating with kernel drivers. The probes
-intercept calls from the UA Mixer Engine process to read:
+the standard macOS API for communicating with kernel drivers. The probe script
+is `apollo-selectors.d`, next to `capture.sh` — you can read it before running,
+and run it standalone if you prefer. It records the raw buffer for these
+selectors:
 
-- **Selector 171 (routing)**: The routing table that maps audio channels
-- **Device identification**: Model type and capabilities
+| Selector | What it carries |
+|---|---|
+| 171 | Routing table — channel IDs, types and names, per direction |
+| 130, 131 | Per-channel program burst, including the IO descriptor blocks |
+| 113, 129 | Large payloads, contents not yet identified |
+| 100 | DSP image list |
+| 127 | Firmware block set |
+| 189 | Stream format — channel count and type per direction |
+| 102 | Transport commit — client name, sample rate, buffer size |
 
 These are the same calls the UA software makes during normal operation. The
 DTrace probes only observe — they do not inject, modify, or replay any calls.
+
+Note that the routing table is sent when Console attaches to the device, not
+continuously. If Console is already running and idle for the whole capture
+window, the result will be empty — quit and relaunch Console while the capture
+is running.
 
 ## What this does NOT do
 
 - **ZERO writes to hardware** — The script only reads data that is already
   being exchanged between software components
-- **No network calls** — All output is saved to a local file. Nothing is
-  sent anywhere
 - **No system modifications** — No files are installed, no settings changed
 - **No persistent changes** — Once the script finishes, DTrace stops tracing
 
+## Network
+
+The capture itself makes no network calls, and every file is written locally
+first. At the very end the script offers to upload the JSON report:
+
+- **Run interactively** (the normal case) it asks first and defaults to **no**.
+- **Run non-interactively** — piped, or over SSH with no TTY — it **uploads
+  without asking**, because there is no way to prompt.
+
+If you would rather nothing left the machine at all, answer `n` at the prompt,
+or run with stdin attached to a terminal so the prompt appears. Only the JSON
+report is ever uploaded; the raw selector dumps are never sent automatically.
+
 ## Output
 
-The script produces a single JSON file containing the captured data. You can
-(and should) review this file before submitting it. It contains only hardware
-identifiers and configuration data — no personal information, no audio data,
-no filesystem paths.
+The script produces two files:
+
+- `apollo-macos-capture-<timestamp>.json` — the report: system info, driver
+  version, IORegistry extract, and a per-selector summary (which selectors were
+  seen, how many calls, how many bytes). This is the file the upload sends.
+- `apollo-macos-capture-<timestamp>-selectors.txt` — the raw hexdumps. These
+  stay local unless you attach them to an issue yourself. They are also the
+  part that is actually useful for routing work, so please do attach them.
+
+You can (and should) review both before submitting. They contain hardware
+identifiers, driver configuration and the audio routing payloads — no personal
+information, no audio content, no filesystem paths.
 
 ## Re-enabling SIP
 

--- a/tools/contribute/macos/apollo-selectors.d
+++ b/tools/contribute/macos/apollo-selectors.d
@@ -1,0 +1,205 @@
+/*
+ * apollo-selectors.d — capture UA driver ioctl payloads on macOS
+ *
+ * Traces IOConnectCallStructMethod in the UA Mixer Engine process and dumps
+ * the raw input struct (and the reply, where there is one) for the selectors
+ * that carry the data we need to write a routing config on Linux.
+ *
+ * READ-ONLY. This attaches to an existing userspace process and copies buffers
+ * it was already passing to the kernel. It issues no ioctls and writes nothing
+ * to the hardware.
+ *
+ * Usage (normally invoked by capture.sh, but standalone works):
+ *
+ *   sudo dtrace -s apollo-selectors.d -p $(pgrep -f "UA Mixer Engine")
+ *
+ * Requires SIP disabled. See WHAT-THIS-DOES.md.
+ *
+ * ---------------------------------------------------------------------------
+ * IOConnectCallStructMethod(io_connect_t connection,      -> arg0
+ *                           uint32_t     selector,        -> arg1
+ *                           const void  *inputStruct,     -> arg2
+ *                           size_t       inputStructCnt,  -> arg3
+ *                           void        *outputStruct,    -> arg4
+ *                           size_t      *outputStructCnt) -> arg5
+ * ---------------------------------------------------------------------------
+ *
+ * Selectors traced, and why:
+ *
+ * Observed payload sizes are from a 26k-record x8p capture, and drive the
+ * bucket sizes below:
+ *
+ *   171  GetRoutingTable   1552 B in / 1648 B out. 16-B header {u32 unused,
+ *                          u32 direction, u32 unused, u32 num_channels} +
+ *                          num_channels x 48-B entries {u32 session_id,
+ *                          u32 pad, u32 channel_id, u32 type, char name[32]}.
+ *                          32 input / 34 output entries on an x8p.
+ *   113  2800 B. Large, contents not yet identified. Truncated in the
+ *   129  2800 B. earlier capture -- these two are the outstanding unknowns,
+ *                          and the likeliest home of the two 72-word IO
+ *                          descriptor blocks (input -> SRAM 0xC1A4,
+ *                          output -> 0xC2C4). First word is the length.
+ *   130  136 B. Per-channel program burst. Fully captured already, but it
+ *   131  24 B.  carries userspace pointers rather than descriptor payload.
+ *   189  144 B. Stream format (channel count + type per direction).
+ *   102  48 B.  Transport commit (client name, rate, buffer size).
+ *   100  4 B.   DSP image selector.
+ *   127  16 B.  Firmware block descriptor -- the block itself is DMA'd from
+ *               host memory, so only the descriptor crosses this call.
+ *
+ * Sizing notes -- these matter, and getting them wrong is why the earlier
+ * capture came back short:
+ *
+ *   tracemem()'s length must be a compile-time constant, so we copyin the
+ *   actual arg3 bytes and then trace a fixed bucket size from that scratch
+ *   buffer. Bytes past arg3 in each dump are uninitialised scratch -- ignore
+ *   them and trust the "size=" field in the header line, which is the real
+ *   payload length.
+ *
+ *   The copyin needs scratch space at least as large as the bucket. macOS
+ *   gives no way to raise that (see the pragma block below), so DUMP_LARGE is
+ *   3072 -- above the 2800-byte payloads we actually need, and not far above
+ *   the 2048 that is known to work on this hardware. If scratch still runs
+ *   out, the dtrace:::ERROR clause below reports fault 5 rather than letting
+ *   records vanish.
+ *
+ *   Two buckets rather than one: SEL130 alone fires ~860 times per session,
+ *   so dumping every record at the large size would bury the interesting
+ *   2800-byte records in tens of MB of padding.
+ */
+
+#pragma D option quiet
+#pragma D option bufsize=16m
+#pragma D option dynvarsize=16m
+#pragma D option switchrate=10hz
+
+/*
+ * No scratchsize option here on purpose. It exists on illumos/Solaris DTrace
+ * but Apple's DTrace never picked it up -- setting it is a hard compile error
+ * ("scratchsize is not a valid option"), not a warning. Scratch space is a
+ * fixed per-CPU size on macOS and cannot be tuned from the script, which is
+ * why DUMP_LARGE is kept only just above the largest payload we need rather
+ * than rounded up to something comfortable.
+ *
+ * bufsize is per-CPU, so 16m on a 10-core machine is already a 160 MB
+ * allocation. With switchrate draining to the output file 10x a second there
+ * is no reason to go higher, and a too-large request can simply fail.
+ */
+
+/*
+ * Deliberately no cpp macro for the selector list: #define would require
+ * `dtrace -C`, and this script is meant to also work as a bare
+ * `dtrace -s apollo-selectors.d`. The list is written out in the two clauses
+ * that need it; the rest key off self->sel.
+ */
+inline int DUMP_SMALL = 256;
+inline int DUMP_LARGE = 3072;
+
+dtrace:::BEGIN
+{
+	nerrors = 0;
+	printf("# open-apollo macOS selector capture\n");
+	printf("# Each record: '=== SELn size=N' followed by a tracemem hexdump.\n");
+	printf("# Only the first 'size' bytes of each dump are real payload.\n");
+	printf("#\n");
+}
+
+/*
+ * Surface faults instead of losing records silently. The one that matters
+ * here is fault 5 (DTRACEFLT_NOSCRATCH) -- copyin had nowhere to land, which
+ * on macOS can only be fixed by lowering DUMP_LARGE, since scratch space is
+ * not tunable. Fault 1 (BADADDR) on a copyin usually just means the buffer
+ * was unmapped at that instant and is harmless if rare.
+ */
+dtrace:::ERROR
+{
+	nerrors = nerrors + 1;
+	printf("\n### DTRACE ERROR fault=%d addr=0x%x\n", arg4, arg5);
+}
+
+/*
+ * Entry: dump the input struct.
+ *
+ * The size guard is deliberate -- copyin(ptr, 0) is an error, and an
+ * absurd length means we misread the frame and should skip rather than
+ * fault the probe.
+ */
+pid$target::IOConnectCallStructMethod:entry
+/(arg1 == 171 || arg1 == 130 || arg1 == 131 || arg1 == 113 || arg1 == 129 ||
+  arg1 == 100 || arg1 == 127 || arg1 == 189 || arg1 == 102) &&
+ arg2 != 0 && arg3 > 0 && arg3 <= DUMP_LARGE/
+{
+	self->sel  = arg1;
+	self->obuf = arg4;
+	self->ocnt = arg5;
+
+	printf("\n=== SEL%d dir=in size=%d ts=%d\n", arg1, arg3, timestamp);
+}
+
+pid$target::IOConnectCallStructMethod:entry
+/self->sel && arg3 <= DUMP_SMALL/
+{
+	tracemem(copyin(arg2, arg3), DUMP_SMALL);
+}
+
+pid$target::IOConnectCallStructMethod:entry
+/self->sel && arg3 > DUMP_SMALL/
+{
+	tracemem(copyin(arg2, arg3), DUMP_LARGE);
+}
+
+/*
+ * A payload larger than DUMP_LARGE would be silently cut, which is exactly
+ * the failure we are trying to stop repeating. Record it loudly instead.
+ */
+pid$target::IOConnectCallStructMethod:entry
+/(arg1 == 171 || arg1 == 130 || arg1 == 131 || arg1 == 113 || arg1 == 129 ||
+  arg1 == 100 || arg1 == 127 || arg1 == 189 || arg1 == 102) &&
+ arg3 > DUMP_LARGE/
+{
+	printf("\n=== SEL%d dir=in size=%d OVERSIZE-NOT-DUMPED ts=%d\n",
+	    arg1, arg3, timestamp);
+	printf("# raise DUMP_LARGE above %d and re-run to capture this one\n",
+	    arg3);
+}
+
+/* Return: resolve the reply length, which is behind a size_t pointer. */
+pid$target::IOConnectCallStructMethod:return
+/self->sel && self->ocnt != 0/
+{
+	self->olen = *(uint64_t *)copyin(self->ocnt, sizeof(uint64_t));
+}
+
+pid$target::IOConnectCallStructMethod:return
+/self->sel/
+{
+	printf("\n=== SEL%d dir=out size=%d rc=0x%x ts=%d\n",
+	    self->sel, self->olen, arg1, timestamp);
+}
+
+pid$target::IOConnectCallStructMethod:return
+/self->sel && self->obuf != 0 && self->olen > 0 && self->olen <= DUMP_SMALL/
+{
+	tracemem(copyin(self->obuf, self->olen), DUMP_SMALL);
+}
+
+pid$target::IOConnectCallStructMethod:return
+/self->sel && self->obuf != 0 && self->olen > DUMP_SMALL &&
+ self->olen <= DUMP_LARGE/
+{
+	tracemem(copyin(self->obuf, self->olen), DUMP_LARGE);
+}
+
+pid$target::IOConnectCallStructMethod:return
+/self->sel/
+{
+	self->sel  = 0;
+	self->obuf = 0;
+	self->ocnt = 0;
+	self->olen = 0;
+}
+
+dtrace:::END
+{
+	printf("\n# capture ended, %d dtrace errors\n", nerrors);
+}

--- a/tools/contribute/macos/capture.sh
+++ b/tools/contribute/macos/capture.sh
@@ -80,10 +80,15 @@ echo ""
 # Parse arguments
 # ============================================================================
 OUTPUT=""
+CAPTURE_SECONDS=30
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --output)
             OUTPUT="$2"
+            shift 2
+            ;;
+        --seconds)
+            CAPTURE_SECONDS="$2"
             shift 2
             ;;
         *)
@@ -96,6 +101,9 @@ if [ -z "$OUTPUT" ]; then
     OUTPUT="./apollo-macos-capture-$(date +%Y%m%d-%H%M%S).json"
 fi
 
+# Resolve alongside this script so apollo-selectors.d is found regardless of cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
@@ -104,8 +112,16 @@ echo "  - Device configuration (model, channels, sample rate)"
 echo "  - Routing table data (SEL171 — how audio channels are mapped)"
 echo "  - Register snapshot (read-only status registers)"
 echo ""
-echo "Capture will run for approximately 10 seconds."
+echo "Capture will run for approximately ${CAPTURE_SECONDS} seconds."
 echo "Make sure UA Console / UA Connect is running."
+echo ""
+echo "IMPORTANT — the routing and config payloads are sent when the device is"
+echo "programmed, not continuously. If Console sits idle for the whole window,"
+echo "the capture comes back empty. During the window, change the sample rate"
+echo "in the Console footer bar, then change it back."
+echo ""
+echo "Do NOT quit Console to trigger a re-attach: dtrace is attached to the"
+echo "mixer engine process, so quitting Console ends the capture."
 echo ""
 read -rp "Press Enter to start capture, or Ctrl+C to cancel..."
 echo ""
@@ -119,41 +135,116 @@ ioreg -r -c IOAudioDevice 2>/dev/null | grep -A 20 "UAD\|Universal Audio" > "$TM
 # ============================================================================
 # Capture: DTrace probes for routing data
 # ============================================================================
-echo "Running DTrace capture (10 seconds)..."
+echo "Running DTrace capture (${CAPTURE_SECONDS} seconds)..."
 
-# TODO: Fill in actual DTrace probe specifications.
-# The probes target IOConnectCallStructMethod in the UA Mixer Engine process
-# to capture routing table data (SEL171) and device configuration.
-#
-# Probe structure:
-#   pid$target::IOConnectCallStructMethod:entry
-#   - arg0: connection
-#   - arg1: selector number (171 = routing, 131 = mixer param, etc.)
-#   - arg2: pointer to input struct
-#   - arg3: input struct size
-#
-# Example DTrace script (template — actual probe details TBD):
-#
-#   dtrace -n '
-#     pid$target::IOConnectCallStructMethod:entry
-#     /arg1 == 171/
-#     {
-#         printf("SEL171 routing call: size=%d", arg3);
-#         tracemem(copyin(arg2, arg3), 256);
-#     }
-#   ' -p $(pgrep -f "UA Mixer Engine") -o "$TMPDIR/dtrace_routing.out"
+# The probe script lives beside this one so it can also be run standalone.
+# See apollo-selectors.d for the selector list and the sizing constraints.
+PROBE_D="$SCRIPT_DIR/apollo-selectors.d"
+RAW_OUT="${OUTPUT%.json}-selectors.txt"
 
-# Placeholder: write a note that probes need to be filled in
-cat > "$TMPDIR/dtrace_routing.out" << 'PLACEHOLDER'
-# DTrace capture placeholder
-# TODO: Actual DTrace probes will be added as they are verified for each
-# macOS version and Apollo model. The probe targets are:
-#   - SEL171 (GetRoutingTable): Read-only routing configuration
-#   - Device type and channel count identification
-#
-# If you are a developer and want to help define these probes,
-# please open an issue on the Open Apollo repository.
-PLACEHOLDER
+MIXER_PID=$(pgrep -f "UA Mixer Engine" | head -1 || true)
+
+if [ -z "$MIXER_PID" ]; then
+    printf "${YELLOW}UA Mixer Engine is not running — skipping DTrace capture.${NC}\n"
+    echo "Start UA Console (which launches the mixer engine) and re-run."
+    echo "# UA Mixer Engine not running at capture time" > "$RAW_OUT"
+elif [ ! -f "$PROBE_D" ]; then
+    printf "${YELLOW}Probe script not found at $PROBE_D — skipping DTrace capture.${NC}\n"
+    echo "# apollo-selectors.d missing" > "$RAW_OUT"
+else
+    echo "Attaching to UA Mixer Engine (pid $MIXER_PID)..."
+
+    # dtrace exits non-zero if the target dies or the user interrupts, and the
+    # partial output is still worth keeping — don't let `set -e` discard it.
+    # stderr goes to its own file: with -o taking the trace data, an attach
+    # failure would otherwise scroll past unnoticed.
+    # Write straight to the final location, NOT into TMPDIR: the EXIT trap
+    # wipes TMPDIR, so a Ctrl+C on a slow or stuck run would otherwise destroy
+    # the very data the run was for. switchrate keeps this file current.
+    : > "$RAW_OUT"
+    dtrace -s "$PROBE_D" -p "$MIXER_PID" \
+        -o "$RAW_OUT" 2> "$TMPDIR/dtrace_stderr.txt" &
+    DTRACE_PID=$!
+
+    echo ""
+    echo "  ----------------------------------------------------------------"
+    echo "  NOW: change the SAMPLE RATE in the UA Console footer bar."
+    echo "  Switch it (e.g. 44.1k -> 48k), wait a few seconds, switch back."
+    echo ""
+    echo "  That reprograms the device, which is what emits the payloads."
+    echo "  (Buffer size is a per-DAW setting on macOS, not a Console one.)"
+    echo ""
+    echo "  Do NOT quit Console. dtrace is attached to this exact process —"
+    echo "  quitting it ends the capture instead of triggering one."
+    echo "  ----------------------------------------------------------------"
+    echo ""
+
+    # Tick once a second: 45 seconds of silence is indistinguishable from a
+    # hang, and bail immediately if dtrace dies rather than waiting it out.
+    ELAPSED=0
+    while [ "$ELAPSED" -lt "$CAPTURE_SECONDS" ]; do
+        if ! kill -0 "$DTRACE_PID" 2>/dev/null; then
+            printf "\n${YELLOW}dtrace exited on its own after ${ELAPSED}s.${NC}\n"
+            break
+        fi
+        RECS=$(grep -c "^=== SEL" "$RAW_OUT" 2>/dev/null) || RECS=0
+        printf "\r  %3ds / %ds — %s records " "$ELAPSED" "$CAPTURE_SECONDS" "$RECS"
+        sleep 1
+        ELAPSED=$((ELAPSED + 1))
+    done
+    printf "\n"
+
+    # SIGINT so dtrace runs its END clause and flushes the buffer. It does not
+    # always act on it -- detaching from the traced process can block -- so
+    # escalate on a timer instead of blocking forever in `wait`. Records
+    # already on disk are safe either way, since switchrate drains as we go.
+    echo "Stopping capture..."
+    kill -INT "$DTRACE_PID" 2>/dev/null || true
+
+    WAITED=0
+    while kill -0 "$DTRACE_PID" 2>/dev/null && [ "$WAITED" -lt 15 ]; do
+        sleep 1
+        WAITED=$((WAITED + 1))
+    done
+
+    if kill -0 "$DTRACE_PID" 2>/dev/null; then
+        printf "${YELLOW}dtrace ignored SIGINT after 15s — sending TERM.${NC}\n"
+        kill -TERM "$DTRACE_PID" 2>/dev/null || true
+        WAITED=0
+        while kill -0 "$DTRACE_PID" 2>/dev/null && [ "$WAITED" -lt 5 ]; do
+            sleep 1
+            WAITED=$((WAITED + 1))
+        done
+    fi
+
+    if kill -0 "$DTRACE_PID" 2>/dev/null; then
+        printf "${YELLOW}Still running — sending KILL.${NC}\n"
+        kill -KILL "$DTRACE_PID" 2>/dev/null || true
+    fi
+
+    wait "$DTRACE_PID" 2>/dev/null || true
+
+    if [ -s "$TMPDIR/dtrace_stderr.txt" ]; then
+        printf "${YELLOW}dtrace reported:${NC}\n"
+        sed 's/^/    /' "$TMPDIR/dtrace_stderr.txt"
+        echo ""
+    fi
+
+    if grep -q "^=== SEL" "$RAW_OUT" 2>/dev/null; then
+        SEL_COUNT=$(grep -c "^=== SEL" "$RAW_OUT") || SEL_COUNT=0
+        printf "${GREEN}Captured $SEL_COUNT selector records.${NC}\n"
+        if grep -q "OVERSIZE-NOT-DUMPED" "$RAW_OUT" 2>/dev/null; then
+            printf "${YELLOW}Some payloads exceeded the dump limit — see the raw file.${NC}\n"
+        fi
+    else
+        printf "${YELLOW}No selector traffic captured.${NC}\n"
+        echo "Console was most likely idle. Re-run and relaunch UA Console"
+        echo "during the capture window."
+    fi
+
+    # The hexdumps stay in this sibling file rather than being inlined in the
+    # JSON: they run to hundreds of KB, and the JSON is what gets uploaded.
+fi
 
 echo "DTrace capture complete."
 echo ""
@@ -164,6 +255,42 @@ echo ""
 echo "Building report..."
 
 IOREG_CONTENT=$(cat "$TMPDIR/ioregistry.txt" 2>/dev/null | head -50 | sed 's/"/\\"/g' | tr '\n' ' ' || echo "not available")
+
+# Per-selector summary. The hexdumps themselves stay in the sibling raw file —
+# the JSON records only what was seen and how big it was, so the upload stays
+# small and reviewable.
+SEL_SUMMARY=$(awk '
+    /^=== SEL/ {
+        sel = $2; dir = $3; size = $4
+        sub(/^SEL/, "", sel); sub(/^dir=/, "", dir); sub(/^size=/, "", size)
+        key = sel "/" dir
+        count[key]++
+        if (size + 0 > max[key]) max[key] = size + 0
+    }
+    END {
+        first = 1
+        for (k in count) {
+            split(k, p, "/")
+            if (!first) printf ",\n"
+            printf "    {\"selector\": %s, \"direction\": \"%s\", \"calls\": %d, \"max_bytes\": %d}",
+                   p[1], p[2], count[k], max[k]
+            first = 0
+        }
+    }
+' "$RAW_OUT" 2>/dev/null || true)
+
+if [ -z "$SEL_SUMMARY" ]; then
+    ROUTING_STATUS="no selector traffic captured — was UA Console relaunched during the window?"
+else
+    ROUTING_STATUS="captured"
+fi
+
+# Only name the raw file in the report if it actually got written.
+if [ -f "$RAW_OUT" ]; then
+    RAW_BASENAME="$(basename "$RAW_OUT")"
+else
+    RAW_BASENAME=""
+fi
 
 cat > "$OUTPUT" << ENDJSON
 {
@@ -180,8 +307,13 @@ cat > "$OUTPUT" << ENDJSON
   },
   "ioregistry": "$IOREG_CONTENT",
   "routing": {
-    "status": "TODO — DTrace probes not yet defined for this macOS version",
-    "notes": "See WHAT-THIS-DOES.md for details on what will be captured"
+    "status": "$ROUTING_STATUS",
+    "capture_seconds": $CAPTURE_SECONDS,
+    "raw_file": "$RAW_BASENAME",
+    "notes": "Hexdumps are in the sibling *-selectors.txt file, not inlined here. See WHAT-THIS-DOES.md.",
+    "selectors": [
+$SEL_SUMMARY
+    ]
   }
 }
 ENDJSON
@@ -191,6 +323,9 @@ ENDJSON
 # ============================================================================
 echo ""
 printf "${GREEN}Capture saved to: ${OUTPUT}${NC}\n"
+if [ -n "$RAW_BASENAME" ]; then
+    printf "${GREEN}Raw selector dumps: ${RAW_OUT}${NC}\n"
+fi
 echo ""
 
 # ============================================================================
@@ -222,9 +357,11 @@ fi
 
 echo ""
 echo "To also submit manually:"
-echo "  1. Review the file — it contains only hardware identifiers, no personal data"
+echo "  1. Review the files — they contain only hardware identifiers and driver"
+echo "     payloads, no personal data"
 echo "  2. Go to: https://github.com/open-apollo/open-apollo/issues/new?template=device-report.yml"
-echo "  3. Attach the JSON file or paste its contents"
+echo "  3. Attach the JSON file, and the *-selectors.txt file if present —"
+echo "     the raw dumps are the part that is actually useful for routing work"
 echo "  4. Add notes about your Apollo model and macOS version"
 echo ""
 echo "================================================================"


### PR DESCRIPTION
Closes the Tooling item on #52: the DTrace section of `capture.sh` was a `TODO` placeholder that wrote a stub file and reported `"status": "TODO — DTrace probes not yet defined"` in the JSON, so a contributor running it got nothing.

## What's here

`tools/contribute/macos/apollo-selectors.d` — a real probe over `IOConnectCallStructMethod`, dumping the raw input struct and reply for SEL 171, 130, 131, 113, 129, 100, 127, 189 and 102. It also runs standalone (`dtrace -s apollo-selectors.d -p $(pgrep -f "UA Mixer Engine")`), which is deliberate: no cpp macros, because `#define` would require `dtrace -C` and break that invocation.

`capture.sh` drives it and builds the report; `WHAT-THIS-DOES.md` documents what is traced.

## Things that cost me a session each, now encoded in the script

**`scratchsize` does not exist on Apple's DTrace.** It's an illumos/Solaris option; on macOS setting it is a hard compile error, not a warning. Scratch is fixed and untunable there, so the large dump bucket is sized just above the payloads we need (3072 for 2800-byte records) rather than rounded up to something comfortable. A `dtrace:::ERROR` clause reports `DTRACEFLT_NOSCRATCH` so a shortfall appears as an error line instead of silently missing records.

**`bufsize` is per-CPU.** The first version asked for 128m, which on a 10-core machine is a ~1.3 GB request. Now 16m, with `switchrate` draining to the output file continuously.

**Quitting Console does not trigger a capture — it ends one.** `dtrace -p` attaches to the mixer-engine process, so quitting Console kills the target and the relaunched engine has a new pid nothing is watching. The correct trigger is a sample-rate change in the Console footer. (Buffer size is a per-DAW setting on macOS, not a Console one.)

**Two ways the wrapper could lose your data**, both fixed: it now writes straight to the final `-selectors.txt` rather than into the temp dir the `EXIT` trap wipes, so Ctrl+C keeps what was captured; and it escalates INT → TERM → KILL instead of blocking in `wait()`, which dtrace does not reliably return from while detaching from the traced process.

It also ticks `Ns / Ns — N records` once a second, because a silent 45-second window is indistinguishable from a hang, and captures dtrace's stderr separately — with `-o` taking the trace data, an attach failure would otherwise scroll past unnoticed.

## Documentation correction

`WHAT-THIS-DOES.md` claimed "**No network calls** — All output is saved to a local file. Nothing is sent anywhere." That did not match the script, which ends with a telemetry upload and **auto-sends when there is no TTY**. In a document whose job is to convince someone it is safe to disable SIP, that seemed worth getting right. I only corrected the description — the upload behaviour is unchanged, and is yours to decide on.

## Verification

macOS 12.7.6, UAD2System 11.9.0 build 389, Apollo x8p. A 45-second run captured **46 SEL113 and 46 SEL129 records at the full 2800 bytes each** — previously truncated at 256 — plus SEL102, SEL127, SEL100, SEL131 and SEL189. Zero dtrace errors, nothing flagged oversize, hexdumps complete to the end of the bucket.

The selector sizes and call counts driving the two-bucket choice come from a separate 26,216-record capture on the same unit.

## Note

The captures this produced did not, in the end, contain the IO descriptors #52 was after — those turn out to be device-generated and never cross the IOKit boundary, which is what #63 addresses. This is still the tooling the issue asks for, and it is what established that negative result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
