### PR TITLE
fix(driver): correct the x8p DMA channel counts to 34 play / 32 rec

### DIFF
--- a/driver/ua_audio.c
+++ b/driver/ua_audio.c
@@ -92,7 +92,7 @@ static const struct ua_model_info ua_models[] = {
 	{ UA_DEV_APOLLO_X8,           26, 26,  4, 2 },
 	{ UA_DEV_APOLLO_X8_GEN2,     26, 26,  4, 2 },
 	{ UA_DEV_APOLLO_8P,           26, 26,  8, 2 },
-	{ UA_DEV_APOLLO_X8P,          26, 26,  8, 2 },
+	{ UA_DEV_APOLLO_X8P,          34, 32,  8, 2 },
 	{ UA_DEV_APOLLO_X8P_GEN2,    26, 26,  8, 2 },
 	{ UA_DEV_APOLLO_X16,          34, 34,  8, 2 },
 	{ UA_DEV_APOLLO_X16_GEN2,    34, 34,  8, 2 },


### PR DESCRIPTION
`ua_models[]` pins the x8p at 26 play / 26 rec. The x4 row above it quotes measured macOS `IOAudioEngine` values; the x8p row cites nothing, and 26/26 matches neither the device's own routing tables nor its mixer control tree.

One line. But it changes DMA buffer sizing and the `AX_PLAY_CH`/`AX_REC_CH` writes, and a wrong value here is what hard-froze the host before `2df18d5`, so the reasoning and the testing are both below.

## Where 32/34 comes from

**The routing-table header carries the DMA channel count.** The x4 config in `ua_routing.h` demonstrates the relationship — its rec header reads 22 against `.rec_channels = 22`, its play header 24 against `.play_channels = 24`. On the x8p those headers read **32 record / 34 playback**.

**The mixer control tree agrees independently**: `/inputroutes` has 32 entries, `/outputroutes` has 34.

Two unrelated sources, same answer.

Worth noting what does *not* settle it, since both look tempting:

- **`AX_PLAY_CH`/`AX_REC_CH` are circular.** The driver writes them from this very table, so reading them back just echoes the current value.
- **The IO descriptors are the wrong structure.** They describe the platform's full mixer topology, not one model's DMA channels — the x4's input descriptor is compositionally identical to the x8p's, 34 entries including 8 ADAT and LINE 5-8 that no x4 physically has. Sizing from those gives 34/36, which is wrong.

## What was hidden

At 26 the driver was dropping 6 record channels (MON L/R, AUX1 L/R, AUX2 L/R) and 8 playback (the four CUE sends).

## Buffer geometry

No change needed. `ua_calc_buf_frame_size()` divides the 4 MiB DMA buffer by the channel count, and at 34 channels the result still clamps to `UA_MAX_BUF_FRAMES`, so `buf_frame_size` stays 8192 and uses 1.06 MiB of the 4 MiB available. Block size moves 207 → 271.

## Testing

Kernel 7.1.5-201.fc44, Apollo x8p at `0000:40:00.0`, module signed with the enrolled DKMS key. Power-cycled first, to clear the stale firmware state a warm module reload leaves behind.

```
ua_apollo: audio: 34 play ch, 32 rec ch, 8192 frame buf
ua_apollo: pcm_prepare: stream=rec channels=32 connected=1 transport=1 aceface=1
AX_PLAY_CH=34  AX_REC_CH=32  AX_DMA_BLKSZ=271
```

`AX_DMA_BLKSZ` read back as the **predicted** 271 rather than being clamped, and `AX_SAMPLE_POS` and `AX_FRAME_CTR` both advanced.

A 25-second 32-channel capture through PipeWire produced 153 MB — exactly 32 ch × 4 B × 48 kHz × 25 s, no short reads — and carried signal on the newly exposed AUX1 pair at DMA 26/27 as well as on the live preamps. **Zero DMAR faults, zero xruns, `pw-top` `ERR 0` on every node.**

PipeWire now advertises 32 in / 34 out on the pro-audio nodes, up from 26/26.

Builds clean with the same warning set as pristine master (diffed, not eyeballed).

## Relationship to #65

#65 adds the x8p routing config and deliberately leaves this table alone, flagging the disagreement instead — a data commit was the wrong place to change DMA geometry. This is that change, separately, with its own testing. The two are independent and can land in either order.

## One caveat

Verified on an x8p only. `UA_DEV_APOLLO_8P` and `UA_DEV_APOLLO_X8P_GEN2` share the 26/26 row but are untouched here, since I cannot test them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
