### PR TITLE
fix(usb-re): parse the 4-byte DSP bulk header as bytes, not <HBB

### DIFF
--- a/tools/usb-re/pcap-mixer-decode.py
+++ b/tools/usb-re/pcap-mixer-decode.py
@@ -81,8 +81,9 @@ class DspCommand:
     """Decoded DSP bulk command/response."""
     timestamp: float
     direction: str          # "OUT" or "IN"
-    word_count: int
-    cmd_type: int           # sub-type byte
+    word_count: int         # payload length in 32-bit dwords
+    flags: int              # 0x00 or 0x10
+    seq: int                # sequence counter, wraps at 256
     magic: int              # 0xDC or 0xDD
     subcmds: list = field(default_factory=list)  # [(opcode, param, value), ...]
     raw: bytes = b""
@@ -167,7 +168,11 @@ def decode_dsp_packet(pkt):
     if len(pkt.data) < 4:
         return None
 
-    word_count, cmd_type, magic = struct.unpack_from("<HBB", pkt.data, 0)
+    # The header is four independent bytes, not a u16 word count followed by
+    # two bytes. Reading it as "<HBB" folds the flags byte into word_count and
+    # shifts seq into its place, which silently mangles every packet that has
+    # flags == 0x10 (about half of them on Apollo Twin USB).
+    word_count, flags, seq, magic = struct.unpack_from("<BBBB", pkt.data, 0)
 
     if magic not in (MAGIC_CMD, MAGIC_RSP):
         return None
@@ -176,7 +181,8 @@ def decode_dsp_packet(pkt):
         timestamp=pkt.timestamp,
         direction=pkt.direction,
         word_count=word_count,
-        cmd_type=cmd_type,
+        flags=flags,
+        seq=seq,
         magic=magic,
         raw=pkt.data,
     )
@@ -303,7 +309,8 @@ def build_mapping(correlations):
                     "value": value,
                     "param_hex": f"0x{param:04x}",
                     "value_hex": f"0x{value:08x}",
-                    "cmd_type": cmd.cmd_type,
+                    "flags": cmd.flags,
+                    "seq": cmd.seq,
                 })
 
     return dict(mapping)
@@ -320,7 +327,7 @@ def print_commands(dsp_cmds, limit=None):
         dir_arrow = "→" if cmd.direction == "OUT" else "←"
         subcmd_strs = [format_subcmd(o, p, v) for o, p, v in cmd.subcmds]
         print(f"  {cmd.timestamp:.6f} {dir_arrow} {magic_name} "
-              f"type={cmd.cmd_type} words={cmd.word_count} "
+              f"flags=0x{cmd.flags:02x} seq={cmd.seq} words={cmd.word_count} "
               f"[{', '.join(subcmd_strs)}]")
         count += 1
 
@@ -426,7 +433,7 @@ def main():
                     print(f"    op=0x{c['opcode']:04x} "
                           f"param={c['param_hex']} "
                           f"value={c['value_hex']} "
-                          f"type={c['cmd_type']}")
+                          f"flags=0x{c['flags']:02x} seq={c['seq']}")
 
             if args.json:
                 with open(args.json, "w") as f:


### PR DESCRIPTION
`decode_dsp_packet()` reads the bulk header as `"<HBB"`, which makes
`word_count` a u16 built from bytes 0 and 1. Byte 1 isn't part of the count —
it's a flags byte, `0x00` or `0x10`. So every packet with `flags == 0x10` gets
`word_count` inflated by `0x1000`, and `cmd_type` ends up holding byte 2, the
sequence counter, rather than any kind of type.

It's silent, because `flags == 0x00` packets decode correctly and there's
nothing to signal that the rest didn't.

### Evidence

The packet length is an independent witness — for a correct parse,
`4 + word_count * 4` has to equal `len(packet)`. On an Apollo Twin USB capture
(6823 DSP packets, read through this tool's own `read_pcap()`):

```
  "<BBBB" (this PR):  6823/6823 consistent
  "<HBB"  (current):  2833/6823 consistent

  byte1 (flags): {0x00: 2833, 0x10: 3990}
    flags=0x00: n=2833   <BBBB ok=2833   <HBB ok=2833
    flags=0x10: n=3990   <BBBB ok=3990   <HBB ok=0
```

The failures aren't scattered — they're exactly the `flags == 0x10` packets.
I get the same split on a second, independent capture (2341 bulk packets:
1262 at `flags=0x00`, 1079 at `0x10`, `<BBBB` 2341/2341, `<HBB` 1262/2341).

Reproduce on any capture with:

```python
import struct
ok_b = sum(1 for p in pkts if len(p.data) == 4 + p.data[0]*4)
ok_h = sum(1 for p in pkts if len(p.data) == 4 + struct.unpack_from("<H", p.data, 0)[0]*4)
```

### What changed

One file, +14/−7. Fixes the unpack, renames `cmd_type` → `seq` (it was already
reading that byte — the name was just wrong), and exposes `flags` as its own
field.

### One thing to flag

The rename changes a JSON key (`cmd_type` → `seq`, plus a new `flags`) and two
printed labels. That's an output-format change on a tool you may have scripts
around. If you'd rather keep the old key for compatibility I'll happily drop
that half and land only the unpack fix — say the word and I'll push a fixup.

### Context

Found while bringing up an Apollo **Twin** USB (`2b5a:0002`) — the flags byte
is set on roughly half the Twin's init traffic, which is what made it obvious.
I don't know whether Solo traffic uses `0x10` as heavily; if it doesn't, this
would have been invisible on Solo captures, which would explain why it survived
this long.

I've filed a Twin device report separately, and there's a cold-DSP settle-time
observation on #62 that may bear on the packet-28 issue.
