### PR TITLE
fix(tools): detect any live Apollo USB, not only the Solo

### DIFF
--- a/tools/usb-0a-scan.py
+++ b/tools/usb-0a-scan.py
@@ -12,14 +12,30 @@ import usb.core
 import usb.util
 
 UA_VID = 0x2B5A
-APOLLO_SOLO_PID = 0x000D
+LIVE_PIDS = {
+    0x000D: "Apollo Solo USB",
+    0x0002: "Twin USB",
+    0x000F: "Twin X USB",
+}
+
+
+def find_device():
+    """Return (device, model_name) for whichever live Apollo USB is present."""
+    for pid, name in LIVE_PIDS.items():
+        dev = usb.core.find(idVendor=UA_VID, idProduct=pid)
+        if dev:
+            return dev, name
+    return None, None
+
 
 def scan():
-    dev = usb.core.find(idVendor=UA_VID, idProduct=APOLLO_SOLO_PID)
+    dev, model = find_device()
     if not dev:
-        print("Apollo Solo USB not found")
+        print("No live Apollo USB device found "
+              "(expected one of: %s)" %
+              ", ".join(LIVE_PIDS.values()))
         sys.exit(1)
-    print(f"Found: {dev.product}\n")
+    print(f"Found: {model} — {dev.product}\n")
 
     if dev.is_kernel_driver_active(0):
         dev.detach_kernel_driver(0)

--- a/tools/usb-clock-init.py
+++ b/tools/usb-clock-init.py
@@ -14,7 +14,21 @@ import usb.core
 import usb.util
 
 UA_VID = 0x2B5A
-APOLLO_SOLO_PID = 0x000D
+LIVE_PIDS = {
+    0x000D: "Apollo Solo USB",
+    0x0002: "Twin USB",
+    0x000F: "Twin X USB",
+}
+
+
+def find_device():
+    """Return (device, model_name) for whichever live Apollo USB is present."""
+    for pid, name in LIVE_PIDS.items():
+        dev = usb.core.find(idVendor=UA_VID, idProduct=pid)
+        if dev:
+            return dev, name
+    return None, None
+
 
 # UAC 2.0 constants
 UAC2_CS_CUR = 0x01
@@ -28,11 +42,13 @@ CLOCK_ID = 128  # 0x80
 AC_INTERFACE = 1
 
 def probe():
-    dev = usb.core.find(idVendor=UA_VID, idProduct=APOLLO_SOLO_PID)
+    dev, model = find_device()
     if not dev:
-        print("Apollo Solo USB not found")
+        print("No live Apollo USB device found "
+              "(expected one of: %s)" %
+              ", ".join(LIVE_PIDS.values()))
         sys.exit(1)
-    print(f"Found: {dev.product}\n")
+    print(f"Found: {model} — {dev.product}\n")
 
     # Detach kernel driver from audio interfaces if attached
     for intf in [0, 1, 2, 3]:

--- a/tools/usb-ctrl-scan.py
+++ b/tools/usb-ctrl-scan.py
@@ -11,14 +11,30 @@ import usb.core
 import usb.util
 
 UA_VID = 0x2B5A
-APOLLO_SOLO_PID = 0x000D
+LIVE_PIDS = {
+    0x000D: "Apollo Solo USB",
+    0x0002: "Twin USB",
+    0x000F: "Twin X USB",
+}
+
+
+def find_device():
+    """Return (device, model_name) for whichever live Apollo USB is present."""
+    for pid, name in LIVE_PIDS.items():
+        dev = usb.core.find(idVendor=UA_VID, idProduct=pid)
+        if dev:
+            return dev, name
+    return None, None
+
 
 def scan():
-    dev = usb.core.find(idVendor=UA_VID, idProduct=APOLLO_SOLO_PID)
+    dev, model = find_device()
     if not dev:
-        print("Apollo Solo USB not found")
+        print("No live Apollo USB device found "
+              "(expected one of: %s)" %
+              ", ".join(LIVE_PIDS.values()))
         sys.exit(1)
-    print(f"Found: {dev.product}\n")
+    print(f"Found: {model} — {dev.product}\n")
 
     if dev.is_kernel_driver_active(0):
         dev.detach_kernel_driver(0)

--- a/tools/usb-deep-probe.py
+++ b/tools/usb-deep-probe.py
@@ -13,7 +13,21 @@ import usb.core
 import usb.util
 
 UA_VID = 0x2B5A
-APOLLO_SOLO_PID = 0x000D
+LIVE_PIDS = {
+    0x000D: "Apollo Solo USB",
+    0x0002: "Twin USB",
+    0x000F: "Twin X USB",
+}
+
+
+def find_device():
+    """Return (device, model_name) for whichever live Apollo USB is present."""
+    for pid, name in LIVE_PIDS.items():
+        dev = usb.core.find(idVendor=UA_VID, idProduct=pid)
+        if dev:
+            return dev, name
+    return None, None
+
 
 EP_BULK_OUT = 0x01
 EP_BULK_IN = 0x81
@@ -29,11 +43,13 @@ def hex_dump(data, prefix="    "):
         print(f"{prefix}{i:04x}: {hex_part:<48s} {ascii_part}")
 
 def probe():
-    dev = usb.core.find(idVendor=UA_VID, idProduct=APOLLO_SOLO_PID)
+    dev, model = find_device()
     if not dev:
-        print("Apollo Solo USB not found")
+        print("No live Apollo USB device found "
+              "(expected one of: %s)" %
+              ", ".join(LIVE_PIDS.values()))
         sys.exit(1)
-    print(f"Found: {dev.product}\n")
+    print(f"Found: {model} — {dev.product}\n")
 
     if dev.is_kernel_driver_active(0):
         dev.detach_kernel_driver(0)

--- a/tools/usb-dsp-probe.py
+++ b/tools/usb-dsp-probe.py
@@ -13,7 +13,21 @@ import usb.core
 import usb.util
 
 UA_VID = 0x2B5A
-APOLLO_SOLO_PID = 0x000D
+LIVE_PIDS = {
+    0x000D: "Apollo Solo USB",
+    0x0002: "Twin USB",
+    0x000F: "Twin X USB",
+}
+
+
+def find_device():
+    """Return (device, model_name) for whichever live Apollo USB is present."""
+    for pid, name in LIVE_PIDS.items():
+        dev = usb.core.find(idVendor=UA_VID, idProduct=pid)
+        if dev:
+            return dev, name
+    return None, None
+
 
 EP_BULK_OUT = 0x01
 EP_BULK_IN = 0x81
@@ -43,11 +57,13 @@ def try_cmd(dev, name, data, timeout=500):
     return None
 
 def probe():
-    dev = usb.core.find(idVendor=UA_VID, idProduct=APOLLO_SOLO_PID)
+    dev, model = find_device()
     if not dev:
-        print("Apollo Solo USB not found")
+        print("No live Apollo USB device found "
+              "(expected one of: %s)" %
+              ", ".join(LIVE_PIDS.values()))
         sys.exit(1)
-    print(f"Found: {dev.product}")
+    print(f"Found: {model} — {dev.product}")
 
     if dev.is_kernel_driver_active(0):
         dev.detach_kernel_driver(0)

--- a/tools/usb-full-init.py
+++ b/tools/usb-full-init.py
@@ -19,7 +19,22 @@ import usb.core
 import usb.util
 
 UA_VID = 0x2B5A
-SOLO_PID = 0x000D
+LIVE_PIDS = {
+    0x000D: "Apollo Solo USB",
+    0x0002: "Twin USB",
+    0x000F: "Twin X USB",
+}
+
+
+def find_device():
+    """Return (device, model_name) for whichever live Apollo USB is present."""
+    for pid, name in LIVE_PIDS.items():
+        dev = usb.core.find(idVendor=UA_VID, idProduct=pid)
+        if dev:
+            return dev, name
+    return None, None
+
+
 EP_BULK_OUT = 0x01
 EP_BULK_IN = 0x81
 # Look for init sequence in both repo layout and installed layout
@@ -127,11 +142,13 @@ def replay_init_sequence(dev, bin_path):
     print(f"  Sent all {count} packets")
 
 
-dev = usb.core.find(idVendor=UA_VID, idProduct=SOLO_PID)
+dev, model = find_device()
 if not dev:
-    print("Apollo Solo USB not found")
+    print("No live Apollo USB device found "
+          "(expected one of: %s)" %
+          ", ".join(LIVE_PIDS.values()))
     sys.exit(1)
-print(f"Found: {dev.product}")
+print(f"Found: {model} — {dev.product}")
 
 if not os.path.exists(INIT_BIN):
     print(f"Missing: {INIT_BIN}")

--- a/tools/usb-mixer-test.py
+++ b/tools/usb-mixer-test.py
@@ -32,7 +32,7 @@ LIVE_PIDS = {
 }
 
 
-def find_device():
+def find_live_device():
     """Return (device, model_name) for whichever live Apollo USB is present."""
     for pid, name in LIVE_PIDS.items():
         dev = usb.core.find(idVendor=UA_VID, idProduct=pid)
@@ -57,7 +57,7 @@ def setting_word(mask, value):
 
 
 def find_device():
-    dev, model = find_device()
+    dev, model = find_live_device()
     if not dev:
         print("No live Apollo USB device found "
               "(expected one of: %s)" %

--- a/tools/usb-mixer-test.py
+++ b/tools/usb-mixer-test.py
@@ -25,7 +25,21 @@ except ImportError:
     sys.exit(1)
 
 UA_VID = 0x2B5A
-SOLO_PID = 0x000D
+LIVE_PIDS = {
+    0x000D: "Apollo Solo USB",
+    0x0002: "Twin USB",
+    0x000F: "Twin X USB",
+}
+
+
+def find_device():
+    """Return (device, model_name) for whichever live Apollo USB is present."""
+    for pid, name in LIVE_PIDS.items():
+        dev = usb.core.find(idVendor=UA_VID, idProduct=pid)
+        if dev:
+            return dev, name
+    return None, None
+
 
 # FPGA addresses for vendor request 0x03
 SETTINGS_SEQ = 0x0602       # 4B: sequence counter
@@ -43,9 +57,11 @@ def setting_word(mask, value):
 
 
 def find_device():
-    dev = usb.core.find(idVendor=UA_VID, idProduct=SOLO_PID)
+    dev, model = find_device()
     if not dev:
-        print("Apollo Solo USB not found (VID 0x2B5A PID 0x000D)")
+        print("No live Apollo USB device found "
+              "(expected one of: %s)" %
+              ", ".join(LIVE_PIDS.values()))
         print("Is firmware loaded? Run: sudo python3 tools/fx3-load.py")
         sys.exit(1)
     print(f"Found: {dev.manufacturer} {dev.product}")

--- a/tools/usb-probe.py
+++ b/tools/usb-probe.py
@@ -12,7 +12,21 @@ import usb.core
 import usb.util
 
 UA_VID = 0x2B5A
-APOLLO_SOLO_PID = 0x000D
+LIVE_PIDS = {
+    0x000D: "Apollo Solo USB",
+    0x0002: "Twin USB",
+    0x000F: "Twin X USB",
+}
+
+
+def find_device():
+    """Return (device, model_name) for whichever live Apollo USB is present."""
+    for pid, name in LIVE_PIDS.items():
+        dev = usb.core.find(idVendor=UA_VID, idProduct=pid)
+        if dev:
+            return dev, name
+    return None, None
+
 
 # DSP interface endpoints
 EP_BULK_OUT = 0x01  # EP1 OUT - commands to device
@@ -20,12 +34,14 @@ EP_BULK_IN = 0x81   # EP1 IN  - responses from device
 EP_INTR_IN = 0x86   # EP6 IN  - notifications from device
 
 def probe():
-    dev = usb.core.find(idVendor=UA_VID, idProduct=APOLLO_SOLO_PID)
+    dev, model = find_device()
     if not dev:
-        print("Apollo Solo USB not found")
+        print("No live Apollo USB device found "
+              "(expected one of: %s)" %
+              ", ".join(LIVE_PIDS.values()))
         sys.exit(1)
 
-    print(f"Found: {dev.product} (serial: {dev.serial_number})")
+    print(f"Found: {model} — {dev.product} (serial: {dev.serial_number})")
     print(f"Bus {dev.bus} Device {dev.address}")
 
     # Detach kernel driver from interface 0 (DSP)

--- a/tools/usb-reg-probe.py
+++ b/tools/usb-reg-probe.py
@@ -12,7 +12,21 @@ import usb.core
 import usb.util
 
 UA_VID = 0x2B5A
-APOLLO_SOLO_PID = 0x000D
+LIVE_PIDS = {
+    0x000D: "Apollo Solo USB",
+    0x0002: "Twin USB",
+    0x000F: "Twin X USB",
+}
+
+
+def find_device():
+    """Return (device, model_name) for whichever live Apollo USB is present."""
+    for pid, name in LIVE_PIDS.items():
+        dev = usb.core.find(idVendor=UA_VID, idProduct=pid)
+        if dev:
+            return dev, name
+    return None, None
+
 
 # Key register offsets from Thunderbolt driver
 REGS = {
@@ -28,11 +42,13 @@ REGS = {
 }
 
 def probe():
-    dev = usb.core.find(idVendor=UA_VID, idProduct=APOLLO_SOLO_PID)
+    dev, model = find_device()
     if not dev:
-        print("Apollo Solo USB not found")
+        print("No live Apollo USB device found "
+              "(expected one of: %s)" %
+              ", ".join(LIVE_PIDS.values()))
         sys.exit(1)
-    print(f"Found: {dev.product}\n")
+    print(f"Found: {model} — {dev.product}\n")
 
     if dev.is_kernel_driver_active(0):
         dev.detach_kernel_driver(0)


### PR DESCRIPTION
Nine of the USB tools hardcode `idProduct=0x000D` and exit with
`"Apollo Solo USB not found"` on a Twin USB (`0x0002`) or Twin X USB (`0x000F`),
even though both PIDs are supported elsewhere in the tree — including in
`usb-dsp-init.py`, right next door.

This is what #39 ran into. That reporter had a working Twin, got audio out of
it, and still couldn't use `usb-mixer-test.py` because it told them their device
wasn't there. The issue was closed without the underlying cause being addressed.

Affected: `usb-probe.py`, `usb-reg-probe.py`, `usb-mixer-test.py`,
`usb-deep-probe.py`, `usb-dsp-probe.py`, `usb-0a-scan.py`, `usb-ctrl-scan.py`,
`usb-clock-init.py`, `usb-full-init.py`.

### Approach

`usb-dsp-init.py` already solves this with a `LIVE_PIDS` table and a
`find_device()` helper. I copied that pattern verbatim rather than inventing a
new one, so every hunk is identical and the tools stay standalone — they're
meant to be run directly as `sudo python3 tools/<tool>.py`, and a shared import
would have made that depend on cwd or `sys.path`.

That does mean the small helper is duplicated nine times. Given you just removed
205k lines of over-engineering I'd rather bring that up than quietly add an
abstraction layer: if you'd prefer a shared `tools/_apollo_usb.py`, say so and
I'll rework it.

### Verified

On an Apollo Twin USB DUO:

```
Found: Twin USB — Apollo Twin USB DUO
  VID:PID = 0x2b5a:0x0002  bus=8 addr=2

old single-PID lookup (0x000D only): Apollo Solo USB not found  <-- issue #39
```

All nine byte-compile. I don't have a Solo or a Twin X, so the Solo path is
unchanged-by-construction rather than retested — `0x000D` is still first in the
lookup order.
