### PR TITLE
fix(udev): add to SYSTEMD_WANTS with += instead of overwriting it

### DIFF
--- a/configs/udev/99-apollo-usb.rules
+++ b/configs/udev/99-apollo-usb.rules
@@ -9,7 +9,7 @@
 # Requires firmware in /lib/firmware/universal-audio/
 # See docs/usb-apollo-re/ for details.
 #
-# IMPORTANT: init runs via systemd (TAG+="systemd", ENV{SYSTEMD_WANTS}=...),
+# IMPORTANT: init runs via systemd (TAG+="systemd", ENV{SYSTEMD_WANTS}+=...),
 # NOT via RUN+=. systemd-udevd.service runs with MemoryDenyWriteExecute and
 # a restrictive SystemCallFilter; RUN+= children inherit that sandbox, which
 # breaks Python's import of pyusb (silent "ModuleNotFoundError: No module
@@ -17,26 +17,31 @@
 # transient race). Plain systemd services started via SYSTEMD_WANTS don't
 # inherit systemd-udevd's sandbox. See configs/systemd/ua-usb-init@.service
 # and configs/systemd/ua-usb-dsp-init.service.
+#
+# SYSTEMD_WANTS is a space-separated list, so it is added to with "+=".
+# A plain "=" would overwrite whatever an earlier-sorting rules file put
+# there, and the loss is silent: the device enumerates, no unit starts,
+# and only `udevadm test` shows the other file's unit is gone.
 
 # FX3 firmware loader stubs — upload firmware on hotplug
 ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="2b5a", ATTR{idProduct}=="000c", \
-  TAG+="systemd", ENV{SYSTEMD_WANTS}="ua-usb-init@ApolloSolo.bin.service"
+  TAG+="systemd", ENV{SYSTEMD_WANTS}+="ua-usb-init@ApolloSolo.bin.service"
 
 ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="2b5a", ATTR{idProduct}=="0001", \
-  TAG+="systemd", ENV{SYSTEMD_WANTS}="ua-usb-init@ApolloTwin.bin.service"
+  TAG+="systemd", ENV{SYSTEMD_WANTS}+="ua-usb-init@ApolloTwin.bin.service"
 
 ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="2b5a", ATTR{idProduct}=="000e", \
-  TAG+="systemd", ENV{SYSTEMD_WANTS}="ua-usb-init@ApolloTwinX.bin.service"
+  TAG+="systemd", ENV{SYSTEMD_WANTS}+="ua-usb-init@ApolloTwinX.bin.service"
 
 # Post-firmware device — run DSP init after enumeration
 ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="2b5a", ATTR{idProduct}=="000d", \
-  TAG+="systemd", ENV{SYSTEMD_WANTS}="ua-usb-dsp-init.service"
+  TAG+="systemd", ENV{SYSTEMD_WANTS}+="ua-usb-dsp-init.service"
 
 ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="2b5a", ATTR{idProduct}=="0002", \
-  TAG+="systemd", ENV{SYSTEMD_WANTS}="ua-usb-dsp-init.service"
+  TAG+="systemd", ENV{SYSTEMD_WANTS}+="ua-usb-dsp-init.service"
 
 ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="2b5a", ATTR{idProduct}=="000f", \
-  TAG+="systemd", ENV{SYSTEMD_WANTS}="ua-usb-dsp-init.service"
+  TAG+="systemd", ENV{SYSTEMD_WANTS}+="ua-usb-dsp-init.service"
 
 # Clear the ua-usb-dsp-init idempotency stamp on unplug, so a fresh replug
 # re-runs DSP init instead of being skipped by the rebind-loop guard.


### PR DESCRIPTION
`configs/udev/99-apollo-usb.rules` assigns `ENV{SYSTEMD_WANTS}` with a plain `=`. `SYSTEMD_WANTS` is a space-separated list of units, and `=` replaces whatever an earlier-sorting rules file put there — so any other unit wanted for the same device is dropped, silently. The device enumerates, no unit starts, and only `udevadm test` shows the other file's unit is gone.

I hit this on an Apollo Twin USB with a device-specific rules file alongside yours (mentioned in #69): the only way to make mine survive was to name it `99-zz-…` so it sorted last and did the clobbering instead. With `+=` both files compose and nobody has to know about the ordering.

### What changed

Six assignments, `=` → `+=`, plus a comment saying why. With no other rules file present the list has one element either way, so behaviour is unchanged.

### Verified

- `udevadm verify configs/udev/99-apollo-usb.rules` passes (systemd 261).
- `+=` on `ENV{SYSTEMD_WANTS}` is the documented form: udev(7) lists `+=` as "add the value to a key that holds a list of entries", and systemd.device(5) describes `SYSTEMD_WANTS` as a space-separated list.
- On hardware, the `=` clobber is what I observed on 2026-08-24 — Twin enumerated, no service fired, `udevadm test` showed only `ua-usb-dsp-init.service`. I have not re-run `install-usb.sh` with this file since I don't use the Solo-derived init path on the Twin, so "still starts `ua-usb-dsp-init.service` on a Solo" is unchanged-by-construction rather than retested.

Adjacent to #60 (which introduced the `SYSTEMD_WANTS` trigger) but a separate mechanism.
