### PR TITLE
fix(install-usb): re-check every dependency after installing, not just pyusb

### DIFF
--- a/scripts/install-usb.sh
+++ b/scripts/install-usb.sh
@@ -127,27 +127,29 @@ fi
 # ================================================================
 header "Dependencies"
 
-DEPS_NEEDED=()
+# Everything the rest of the installer needs, in one place so the same
+# check runs before AND after the package manager.  The install commands
+# below deliberately ignore the package manager's exit status (a partial
+# failure must not abort a run that can still succeed), so a re-check is
+# the only thing that catches a package that did not actually land.
+missing_deps() {
+    local missing=()
+    command -v python3 &>/dev/null || missing+=(python3)
+    python3 -c "import usb.core" 2>/dev/null || missing+=(pyusb)
+    # Kernel headers (needed for snd-usb-audio build)
+    [ -d "/lib/modules/$KERNEL/build" ] || missing+=(kernel-headers)
+    # Build tools — clang if kernel was built with it, else gcc
+    if [ "$KERN_CC" = "clang" ]; then
+        command -v clang &>/dev/null || missing+=(clang)
+    else
+        command -v gcc &>/dev/null || missing+=(gcc)
+    fi
+    command -v make &>/dev/null || missing+=(make)
+    command -v wget &>/dev/null || missing+=(wget)
+    echo "${missing[@]}"
+}
 
-# Check python3
-if ! command -v python3 &>/dev/null; then DEPS_NEEDED+=(python3); fi
-
-# Check pyusb
-if ! python3 -c "import usb.core" 2>/dev/null; then DEPS_NEEDED+=(pyusb); fi
-
-# Check kernel headers (needed for snd-usb-audio build)
-if [ ! -d "/lib/modules/$KERNEL/build" ]; then DEPS_NEEDED+=(kernel-headers); fi
-
-# Check build tools — clang if kernel was built with it, else gcc
-if [ "$KERN_CC" = "clang" ]; then
-    if ! command -v clang &>/dev/null; then DEPS_NEEDED+=(clang); fi
-else
-    if ! command -v gcc &>/dev/null; then DEPS_NEEDED+=(gcc); fi
-fi
-if ! command -v make &>/dev/null; then DEPS_NEEDED+=(make); fi
-
-# Check wget
-if ! command -v wget &>/dev/null; then DEPS_NEEDED+=(wget); fi
+DEPS_NEEDED=($(missing_deps))
 
 if [ ${#DEPS_NEEDED[@]} -eq 0 ]; then
     ok "All dependencies present"
@@ -187,10 +189,20 @@ else
             run_sudo pip3 install --break-system-packages pyusb 2>/dev/null
     fi
 
-    if python3 -c "import usb.core" 2>/dev/null; then
+    # Re-check the full list, not just pyusb.  Before this, a package the
+    # manager failed to install (wget, say) was still reported as
+    # "Dependencies installed" and only surfaced 30 lines later as
+    # "kernel source not available on kernel.org" — the wrong error.
+    STILL_MISSING=($(missing_deps))
+    if [ ${#STILL_MISSING[@]} -eq 0 ]; then
         ok "Dependencies installed"
     else
-        fail "Could not install pyusb — install manually: pip3 install pyusb"
+        fail "Still missing after install: ${STILL_MISSING[*]}"
+        if [[ " ${STILL_MISSING[*]} " == *" pyusb "* ]]; then
+            info "pyusb: pip3 install pyusb (or your distro's python3-usb / python-pyusb package)"
+        fi
+        info "Install the rest with your package manager, then re-run the installer."
+        info "Install will NOT touch the audio stack — your current driver is untouched."
         exit 1
     fi
 fi


### PR DESCRIPTION
The dependency step ignores the package manager's exit status on purpose — a partial failure shouldn't abort a run that can still succeed — but the only thing it verifies afterwards is `import usb.core`. Everything else is assumed to have landed.

On my first run (Arch, 2026-08-24) pacman didn't install `wget`. The installer printed `[ OK ] Dependencies installed`, then thirty lines later:

```
[INFO]  Trying kernel source v7.1.8...
[WARN]  v7.1.8 not available on kernel.org
[WARN]  v7.1 not available on kernel.org
[FAIL]  Could not download kernel source ...
[INFO]  Last wget error (if any):
    bash: line 1: wget: command not found
```

The wget log at the bottom is the only honest line, and it's easy to miss under a `[FAIL]` that points at kernel.org.

### What changed

The checks move into a `missing_deps()` function that runs before **and** after the install. If anything on the list is still missing, it fails closed with that list — nothing has been touched at that point, so exiting is safe. +34/−22, one file, `bash -n` clean.

I kept the package-manager commands themselves as they were (including `2>/dev/null`); this PR only makes the outcome truthful. Happy to also surface the package manager's stderr on failure if you'd like that in the same change.

### Verified

- `missing_deps()` extracted from the script: full `PATH` → `[]`; `PATH=/nonexistent` → `[python3 pyusb gcc make wget]`.
- Not re-run end-to-end on a clean system; the "all present" path is byte-for-byte the old behaviour.
