### PR TITLE
feat(usb-re): extract and replay a complete USB init sequence from a capture

### DIFF
--- a/tools/usb-re/init-replay.py
+++ b/tools/usb-re/init-replay.py
@@ -68,6 +68,45 @@ def read_seq(path):
     return events
 
 
+def phase_registers(records):
+    """Count bulk entries per register per phase.
+
+    records: iterable of (phase, flags, payload_bytes) for bulk packets in
+    order.  Entries are walked with their real length ((reg << 16) |
+    wordcount, wordcount inclusive) and may continue across packets within
+    the same flags stream, so a partial entry carried over from the previous
+    packet of that stream is skipped rather than misread.  An entry counts
+    toward the phase of the packet it starts in.
+    """
+    per_phase = collections.defaultdict(collections.Counter)
+    carry = {}                      # flags -> dwords still owed to an open entry
+    for phase, flags, payload in records:
+        words = struct.unpack_from("<%dI" % (len(payload) // 4), payload, 0)
+        i = carry.get(flags, 0)
+        if i >= len(words):
+            carry[flags] = i - len(words)
+            continue
+        while i < len(words):
+            wc = words[i] & 0xFFFF
+            if wc == 0:
+                break
+            per_phase[phase][words[i] >> 16] += 1
+            i += wc
+        carry[flags] = max(0, i - len(words))
+    return per_phase
+
+
+def describe_phases(per_phase):
+    """Return ({phase: 'top registers'}, chain_phase_or_None)."""
+    top = {}
+    for phase, regs in per_phase.items():
+        top[phase] = " ".join("0x%04x:%d" % (r, n) for r, n in regs.most_common(3))
+    chain = max(per_phase, key=lambda p: per_phase[p][0x000C], default=None)
+    if chain is not None and per_phase[chain][0x000C] < 100:
+        chain = None
+    return top, chain
+
+
 def parse_phases(spec, available):
     if spec == "all":
         return set(available)
@@ -114,10 +153,15 @@ def main():
         for delta, ph, kind, *_ in events:
             per[ph][kind] += 1
             per[ph][2] += delta
-        print("PHASE   BULK  CTRL  captured seconds")
+        top, chain = describe_phases(phase_registers(
+            (ph, data[1], data[4:]) for _, ph, kind, _b, _r, _v, _i, data in events if kind == 0))
+        print("PHASE   BULK  CTRL  captured s  top registers")
         for ph in phases_present:
             mark = "" if ph in want else "   (skipped)"
-            print(f"  {ph:3d} {per[ph][0]:6d} {per[ph][1]:5d} {per[ph][2]:10.2f}{mark}")
+            print(f"  {ph:3d} {per[ph][0]:6d} {per[ph][1]:5d} {per[ph][2]:10.2f}  "
+                  f"{top.get(ph, ''):<24}{mark}")
+        if chain is not None:
+            print(f"plugin chain (reg 0x000c) is phase {chain}")
         for delta, ph, kind, brt, breq, wv, wi, data in sel:
             if kind == 1:
                 print(f"  phase {ph}: CTRL bmRequestType=0x{brt:02x} bReq={breq} "

--- a/tools/usb-re/init-replay.py
+++ b/tools/usb-re/init-replay.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Replay an Apollo USB init sequence built by pcap-init-extract.py.
+
+Sends the captured bulk OUT packets and vendor control OUT transfers to a
+live Apollo (post-firmware PID) in their original order, honouring the
+captured inter-packet timing up to --max-delay, and reports what the DSP
+sent back per phase.
+
+The sequence must come from the same model and firmware as the device it
+is replayed on: DSP addresses inside it are firmware-specific.
+
+Timing that matters, learned on an Apollo Twin USB:
+
+  * Start no earlier than ~30 s after the device re-enumerates with its
+    live PID.  Started ~5 s after enumeration the replay is acknowledged
+    packet for packet, converters and routing come up, and the UAD plugin
+    chain silently never instantiates (issue #62).
+  * Inter-phase gaps are real.  The DSP needs time after program loads;
+    clamping every gap to a small constant works from a warm DSP and
+    fails from a cold one.  --max-delay only caps the longest pauses.
+
+Usage:
+    sudo python3 init-replay.py init.seq --dry-run      # list phases, send nothing
+    sudo python3 init-replay.py init.seq                # replay every phase
+    sudo python3 init-replay.py init.seq --phases 0-5   # bring-up only
+
+Requires: pyusb.
+"""
+
+import argparse
+import collections
+import struct
+import sys
+import time
+
+import usb.core
+import usb.util
+
+UA_VID = 0x2B5A
+LIVE_PIDS = {
+    0x000D: "Apollo Solo USB",
+    0x0002: "Twin USB",
+    0x000F: "Twin X USB",
+}
+EP_BULK_OUT = 0x01
+EP_BULK_IN = 0x81
+HANDSHAKE_REQUESTS = (5, 7, 12, 13)   # arm / commit / apply: the DSP replies to these
+
+
+def find_device():
+    for pid, name in LIVE_PIDS.items():
+        dev = usb.core.find(idVendor=UA_VID, idProduct=pid)
+        if dev:
+            return dev, name
+    return None, None
+
+
+def read_seq(path):
+    with open(path, "rb") as f:
+        if f.read(5) != b"APLO2":
+            sys.exit(f"{path}: not an APLO2 sequence (see pcap-init-extract.py)")
+        count = struct.unpack("<I", f.read(4))[0]
+        events = []
+        for _ in range(count):
+            delta, ph, kind, brt, breq, _pad, wv, wi, ln = \
+                struct.unpack("<IHBBBBHHH", f.read(16))
+            events.append((delta / 1e6, ph, kind, brt, breq, wv, wi, f.read(ln)))
+    return events
+
+
+def parse_phases(spec, available):
+    if spec == "all":
+        return set(available)
+    lo, _, hi = spec.partition("-")
+    lo = int(lo)
+    hi = int(hi) if hi else lo
+    return set(range(lo, hi + 1))
+
+
+def drain(dev, timeout_ms):
+    got = 0
+    try:
+        while True:
+            r = dev.read(EP_BULK_IN, 1024, timeout=timeout_ms)
+            if not len(r):
+                break
+            got += 1
+    except usb.core.USBError:
+        pass
+    return got
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("seq", help="sequence file from pcap-init-extract.py")
+    ap.add_argument("--phases", default="all",
+                    help='phase range to send, e.g. "0-5" (default: all)')
+    ap.add_argument("--max-delay", type=float, default=5.0,
+                    help="cap on any single captured pause, seconds (default 5)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="list what would be sent and exit")
+    a = ap.parse_args()
+
+    events = read_seq(a.seq)
+    phases_present = sorted({e[1] for e in events})
+    want = parse_phases(a.phases, phases_present)
+    sel = [e for e in events if e[1] in want]
+    n_bulk = sum(1 for e in sel if e[2] == 0)
+    print(f"{len(events)} events in {len(phases_present)} phases; "
+          f"sending {len(sel)} ({n_bulk} bulk, {len(sel) - n_bulk} control)")
+
+    if a.dry_run:
+        per = collections.defaultdict(lambda: [0, 0, 0.0])
+        for delta, ph, kind, *_ in events:
+            per[ph][kind] += 1
+            per[ph][2] += delta
+        print("PHASE   BULK  CTRL  captured seconds")
+        for ph in phases_present:
+            mark = "" if ph in want else "   (skipped)"
+            print(f"  {ph:3d} {per[ph][0]:6d} {per[ph][1]:5d} {per[ph][2]:10.2f}{mark}")
+        for delta, ph, kind, brt, breq, wv, wi, data in sel:
+            if kind == 1:
+                print(f"  phase {ph}: CTRL bmRequestType=0x{brt:02x} bReq={breq} "
+                      f"wValue=0x{wv:04x} wIndex=0x{wi:04x} len={len(data)}")
+        return
+
+    dev, name = find_device()
+    if dev is None:
+        sys.exit("no live Apollo USB found (PID 0x000d / 0x0002 / 0x000f)")
+    print(f"Found {name}: {dev.product}")
+    if dev.is_kernel_driver_active(0):
+        dev.detach_kernel_driver(0)
+    usb.util.claim_interface(dev, 0)
+
+    stats = collections.defaultdict(lambda: {"bulk": 0, "ctrl": 0, "resp": 0, "err": 0, "t": 0.0})
+    cur = None
+    t0 = time.time()
+    phase_t0 = t0
+    drain(dev, 200)
+    try:
+        for i, (delta, ph, kind, brt, breq, wv, wi, data) in enumerate(sel):
+            if ph != cur:
+                wait = min(delta, a.max_delay) if delta > 0 else 0.25
+                if cur is not None:
+                    stats[cur]["t"] = time.time() - phase_t0
+                cur = ph
+                print(f"--- phase {ph} (gap {wait:.2f} s)")
+                time.sleep(wait)
+                phase_t0 = time.time()
+            elif delta > 0:
+                time.sleep(min(delta, a.max_delay))
+
+            if kind == 0:
+                try:
+                    dev.write(EP_BULK_OUT, data, timeout=5000)
+                    stats[ph]["bulk"] += 1
+                except usb.core.USBError as e:
+                    stats[ph]["err"] += 1
+                    print(f"    !! bulk write failed in phase {ph}: {e}")
+                    raise
+                # Large packets (program loads) and register reads draw replies
+                is_read = data[0] and (struct.unpack_from("<I", data, 4)[0] & 0xFFFF) == 1
+                if len(data) > 512 or is_read:
+                    stats[ph]["resp"] += drain(dev, 200)
+                elif i % 32 == 0:
+                    stats[ph]["resp"] += drain(dev, 5)
+            else:
+                try:
+                    dev.ctrl_transfer(brt, breq, wv, wi, data if data else None, 3000)
+                    stats[ph]["ctrl"] += 1
+                except usb.core.USBError as e:
+                    stats[ph]["err"] += 1
+                    print(f"    !! control bReq={breq} wValue=0x{wv:04x} failed: {e}")
+                time.sleep(0.02)
+                if breq in HANDSHAKE_REQUESTS:
+                    got = drain(dev, 150)
+                    stats[ph]["resp"] += got
+                    print(f"    ctrl bReq={breq} wValue=0x{wv:04x} -> {got} reply")
+    finally:
+        if cur is not None:
+            stats[cur]["t"] = time.time() - phase_t0
+        stats[cur if cur is not None else 0]["resp"] += drain(dev, 300)
+        usb.util.release_interface(dev, 0)
+        try:
+            dev.attach_kernel_driver(0)
+        except Exception:
+            pass
+
+    total_resp = sum(s["resp"] for s in stats.values())
+    total_err = sum(s["err"] for s in stats.values())
+    print(f"done in {time.time() - t0:.1f} s: {total_resp} responses, {total_err} errors")
+    print("PHASE   BULK  CTRL  RESP  ERR  SECONDS")
+    for ph in sorted(stats):
+        s = stats[ph]
+        print(f"  {ph:3d} {s['bulk']:6d} {s['ctrl']:5d} {s['resp']:5d} {s['err']:4d} {s['t']:8.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/usb-re/pcap-init-extract.py
+++ b/tools/usb-re/pcap-init-extract.py
@@ -143,6 +143,45 @@ def extract(pcap, addr, start, end):
     return events, fw_frames
 
 
+def phase_registers(records):
+    """Count bulk entries per register per phase.
+
+    records: iterable of (phase, flags, payload_bytes) for bulk packets in
+    order.  Entries are walked with their real length ((reg << 16) |
+    wordcount, wordcount inclusive) and may continue across packets within
+    the same flags stream, so a partial entry carried over from the previous
+    packet of that stream is skipped rather than misread.  An entry counts
+    toward the phase of the packet it starts in.
+    """
+    per_phase = collections.defaultdict(collections.Counter)
+    carry = {}                      # flags -> dwords still owed to an open entry
+    for phase, flags, payload in records:
+        words = struct.unpack_from("<%dI" % (len(payload) // 4), payload, 0)
+        i = carry.get(flags, 0)
+        if i >= len(words):
+            carry[flags] = i - len(words)
+            continue
+        while i < len(words):
+            wc = words[i] & 0xFFFF
+            if wc == 0:
+                break
+            per_phase[phase][words[i] >> 16] += 1
+            i += wc
+        carry[flags] = max(0, i - len(words))
+    return per_phase
+
+
+def describe_phases(per_phase):
+    """Return ({phase: 'top registers'}, chain_phase_or_None)."""
+    top = {}
+    for phase, regs in per_phase.items():
+        top[phase] = " ".join("0x%04x:%d" % (r, n) for r, n in regs.most_common(3))
+    chain = max(per_phase, key=lambda p: per_phase[p][0x000C], default=None)
+    if chain is not None and per_phase[chain][0x000C] < 100:
+        chain = None
+    return top, chain
+
+
 def write_seq(events, out, gap):
     recs = []
     phase = 0
@@ -206,10 +245,21 @@ def main():
     for _, ph, e in recs:
         if e[1] == 1:
             ctrl[ph][f"bReq{e[3]}"] += 1
-    print("PHASE   BULK  CTRL  control detail")
+    top, chain = describe_phases(phase_registers(
+        (ph, e[6][1], e[6][4:]) for _, ph, e in recs if e[1] == 0))
+    print("PHASE   BULK  CTRL  top registers            control detail")
     for ph in sorted({p for p, _ in counts}):
         detail = " ".join(f"{k}:{v}" for k, v in sorted(ctrl[ph].items()))
-        print(f"  {ph:3d} {counts.get((ph, 0), 0):6d} {counts.get((ph, 1), 0):5d}  {detail}")
+        print(f"  {ph:3d} {counts.get((ph, 0), 0):6d} {counts.get((ph, 1), 0):5d}  "
+              f"{top.get(ph, ''):<24} {detail}")
+    # Phase numbers depend on where this capture's driver happened to pause,
+    # so say which phase is the plugin-chain upload instead of assuming one.
+    if chain is not None:
+        print(f"plugin chain (reg 0x000c) is phase {chain}; "
+              f"--phases 0-{chain - 1} on init-replay.py is the bring-up without it")
+    else:
+        print("no plugin-chain upload (reg 0x000c) found — Console had no plugins loaded, "
+              "or the capture stopped early")
 
 
 if __name__ == "__main__":

--- a/tools/usb-re/pcap-init-extract.py
+++ b/tools/usb-re/pcap-init-extract.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Extract an Apollo USB init sequence from a USBPcap capture.
+
+Reads a Windows USBPcap capture (.pcap or .pcapng) of the Apollo powering
+on under the UA driver, and writes the host-to-device traffic that brings
+the device up as a replayable sequence for init-replay.py:
+
+  * bulk OUT packets on EP 0x01 (the 0xDC DSP command stream), and
+  * vendor/class control OUT transfers (bmRequestType 0x40/0x41),
+
+interleaved in their original order with the original inter-packet
+timing, split into phases wherever the host paused for longer than
+--gap seconds.  The FX3 firmware download (bRequest 0xA0) is excluded:
+firmware is loaded separately by tools/fx3-load.py from the image UA
+ships.
+
+The control transfers matter.  On an Apollo Twin USB the init is 2341
+bulk packets AND 45 control transfers; a bulk-only replay brings up audio
+but not preamp state or the UAD plugin chain.
+
+Output format ("APLO2"):
+    b"APLO2", u32 count, then per record
+    u32 delta_us   microseconds since the previous record (capped at 5 s)
+    u16 phase      0-based, increments at every gap > --gap
+    u8  kind       0 = bulk OUT, 1 = control OUT
+    u8  bmRequestType, u8 bRequest, u8 pad      (control only)
+    u16 wValue, u16 wIndex                      (control only)
+    u16 len, then len bytes of data
+
+The sequence is specific to the device model and firmware it was captured
+from, and contains DSP program data UA ships with its driver.  Keep it
+local, like the firmware image; see docs/device-capture-windows.
+
+Usage:
+    python3 pcap-init-extract.py capture.pcapng -o init.seq
+    python3 pcap-init-extract.py capture.pcapng -o init.seq --address 11
+    python3 pcap-init-extract.py capture.pcapng -o init.seq --end 1787645258.9
+
+Requires: tshark (Wireshark) on PATH.
+"""
+
+import argparse
+import collections
+import struct
+import subprocess
+import sys
+
+UA_VID = 0x2B5A
+LIVE_PIDS = {
+    0x000D: "Apollo Solo USB",
+    0x0002: "Twin USB",
+    0x000F: "Twin X USB",
+}
+FX3_FW_DOWNLOAD = 0xA0
+MAGIC_CMD = 0xDC
+
+
+def tshark(pcap, display_filter, fields):
+    cmd = ["tshark", "-r", pcap, "-Y", display_filter, "-T", "fields"]
+    for f in fields:
+        cmd += ["-e", f]
+    try:
+        res = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    except FileNotFoundError:
+        sys.exit("tshark not found — install Wireshark (tshark)")
+    except subprocess.CalledProcessError as e:
+        sys.exit(f"tshark failed: {e.stderr.strip()}")
+    return [line.split("\t") for line in res.stdout.splitlines()]
+
+
+def find_live_address(pcap):
+    """Return (device_address, pid) of the post-firmware Apollo in the capture."""
+    seen = {}
+    for row in tshark(pcap, "usb.idVendor == 0x2b5a",
+                      ["usb.device_address", "usb.idProduct"]):
+        if len(row) < 2 or not row[0]:
+            continue
+        seen[int(row[0])] = int(row[1], 16)
+    live = [(a, p) for a, p in seen.items() if p in LIVE_PIDS]
+    if not live:
+        pids = ", ".join(f"0x{p:04x}" for p in seen.values()) or "none"
+        sys.exit(f"no live Apollo (PID 0x000d/0x0002/0x000f) in capture; "
+                 f"VID 2b5a devices seen: {pids}")
+    if len(live) > 1:
+        sys.exit("more than one live Apollo in capture; pick one with --address: "
+                 + ", ".join(f"{a} ({LIVE_PIDS[p]})" for a, p in live))
+    return live[0]
+
+
+def hexbytes(s):
+    return bytes.fromhex(s.replace(":", "")) if s else b""
+
+
+def extract(pcap, addr, start, end):
+    events = []
+    # Bulk OUT on EP 0x01 carrying a 0xDC command
+    for row in tshark(pcap, f"usb.device_address == {addr} && "
+                            f"usb.endpoint_address == 0x01 && usb.capdata",
+                      ["frame.time_epoch", "usb.capdata"]):
+        if len(row) < 2 or not row[1]:
+            continue
+        t = float(row[0])
+        d = hexbytes(row[1])
+        if len(d) < 4 or d[3] != MAGIC_CMD:
+            continue
+        if len(d) != 4 + d[0] * 4:
+            print(f"  ! bulk packet at {t:.6f} has inconsistent length, skipped")
+            continue
+        events.append((t, 0, 0, 0, 0, 0, d))
+    # The FX3 download goes to the loader PID, which has a different device
+    # address, so count it across the whole capture rather than per address.
+    fw_frames = len(tshark(pcap, "usb.bmRequestType == 0x40 && usb.setup.bRequest == 160"
+                                 " && usb.control_stage == 0", ["frame.number"]))
+    # Vendor/class control OUT, setup stage only
+    for row in tshark(pcap, f"usb.device_address == {addr} && "
+                            "(usb.bmRequestType == 0x41 || usb.bmRequestType == 0x40) "
+                            "&& usb.control_stage == 0",
+                      ["frame.time_epoch", "usb.bmRequestType", "usb.setup.bRequest",
+                       "usb.setup.wValue", "usb.setup.wIndex", "usb.setup.wLength",
+                       "usb.data_fragment"]):
+        row = (row + [""] * 7)[:7]
+        if not row[1]:
+            continue
+        t = float(row[0])
+        brt = int(row[1], 16)
+        breq = int(row[2])
+        if breq == FX3_FW_DOWNLOAD:
+            continue
+        wv = int(row[3], 16)
+        wi = int(row[4], 16) if row[4].startswith("0x") else int(row[4] or 0)
+        wl = int(row[5] or 0)
+        d = hexbytes(row[6])
+        if wl and len(d) != wl:
+            print(f"  ! control bReq={breq} wValue=0x{wv:04x} wLength={wl} "
+                  f"but {len(d)} bytes captured, skipped")
+            continue
+        events.append((t, 1, brt, breq, wv, wi, d))
+    events.sort(key=lambda e: e[0])
+    if start is not None:
+        events = [e for e in events if e[0] >= start]
+    if end is not None:
+        events = [e for e in events if e[0] < end]
+    return events, fw_frames
+
+
+def write_seq(events, out, gap):
+    recs = []
+    phase = 0
+    for i, e in enumerate(events):
+        delta = 0.0 if i == 0 else e[0] - events[i - 1][0]
+        if i and delta > gap:
+            phase += 1
+        recs.append((delta, phase, e))
+    with open(out, "wb") as f:
+        f.write(b"APLO2")
+        f.write(struct.pack("<I", len(recs)))
+        for delta, ph, (t, kind, brt, breq, wv, wi, d) in recs:
+            f.write(struct.pack("<IHBBBBHHH", min(int(delta * 1e6), 5_000_000),
+                                ph, kind, brt, breq, 0, wv, wi, len(d)))
+            f.write(d)
+    return recs
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("pcap", help="USBPcap capture (.pcap or .pcapng)")
+    ap.add_argument("-o", "--output", required=True, help="output .seq file")
+    ap.add_argument("--address", type=int, default=None,
+                    help="USB device address of the live Apollo (default: auto)")
+    ap.add_argument("--start", type=float, default=None,
+                    help="ignore events before this epoch time")
+    ap.add_argument("--end", type=float, default=None,
+                    help="ignore events at/after this epoch time (e.g. sweep start)")
+    ap.add_argument("--gap", type=float, default=0.15,
+                    help="idle gap that starts a new phase, seconds (default 0.15)")
+    a = ap.parse_args()
+
+    if a.address is None:
+        addr, pid = find_live_address(a.pcap)
+        print(f"Live Apollo: {LIVE_PIDS[pid]} (PID 0x{pid:04x}) at device address {addr}")
+    else:
+        addr = a.address
+
+    events, fw_frames = extract(a.pcap, addr, a.start, a.end)
+    nb = sum(1 for e in events if e[1] == 0)
+    nc = len(events) - nb
+    if not events:
+        sys.exit("no init traffic found for that device address")
+    print(f"{nb} bulk + {nc} control = {len(events)} events, "
+          f"{events[-1][0] - events[0][0]:.1f} s of wall clock")
+    if fw_frames:
+        print(f"{fw_frames} FX3 firmware frames (bRequest 0xA0) excluded — "
+              f"cold start captured")
+    else:
+        print("warning: no FX3 firmware download in this window — the device was "
+              "already running firmware when the capture started, so this may not "
+              "be a complete init")
+    if nc == 0:
+        print("warning: no control transfers captured; a bulk-only sequence "
+              "replays roughly half of the init")
+
+    recs = write_seq(events, a.output, a.gap)
+    print(f"wrote {a.output}")
+    counts = collections.Counter((ph, e[1]) for _, ph, e in recs)
+    ctrl = collections.defaultdict(collections.Counter)
+    for _, ph, e in recs:
+        if e[1] == 1:
+            ctrl[ph][f"bReq{e[3]}"] += 1
+    print("PHASE   BULK  CTRL  control detail")
+    for ph in sorted({p for p, _ in counts}):
+        detail = " ".join(f"{k}:{v}" for k, v in sorted(ctrl[ph].items()))
+        print(f"  {ph:3d} {counts.get((ph, 0), 0):6d} {counts.get((ph, 1), 0):5d}  {detail}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Two standalone tools under `tools/usb-re/` that turn a Windows USBPcap capture of the UA driver bringing up a USB Apollo into a replayable init sequence, and replay it on Linux. This is the path that got an Apollo Twin USB working end to end (#69) — filed as tools + recipe rather than as a captured sequence, so nobody's captured bytes ship in the repo. The matching how-to page is #79; the protocol findings behind it are #78.

### Why not `usb-full-init.py`

`usb-full-init.py` replays a bulk-only sequence captured from a Solo. Two things stopped that model from working on the Twin:

1. **The init is bulk *and* control.** On the Twin it is 2341 bulk OUT packets **and 45 vendor control OUT transfers** (`bmRequestType 0x41`) interleaved with them — the `bReq 3` settings blocks the mixer section already documents, plus `bReq 5` / `bReq 7` / `12` / `13` with no data. A bulk-only replay is roughly half of it: audio comes up, preamp gain and the UAD chain do not. With the control half, the preamp gain lands (ch0 rises ~55 dB) and the chain runs.
2. The sequence is firmware- and model-specific, so a shipped `.bin` only helps people with the same firmware build — which is what #62's packet-28 crash looks like from here.

### What's in it

- **`pcap-init-extract.py`** — reads `.pcap`/`.pcapng` via `tshark`, auto-detects the live Apollo (any of the three live PIDs; `--address` to override), writes every bulk OUT `0xDC` packet and every vendor/class control OUT transfer in original order with original inter-packet timing, split into phases at idle gaps (`--gap`, default 150 ms). `--start`/`--end` cut a window (e.g. everything before a parameter sweep). The FX3 firmware download (`bRequest 0xA0`) is **excluded** — `fx3-load.py` already handles firmware from the image UA ships, and I didn't want a tool that quietly writes UA's firmware into a second file. It prints a warning if the capture didn't include a cold start, or contains no control transfers.
- **`init-replay.py`** — sends a sequence to a live device (`LIVE_PIDS` lookup, claims interface 0 only), honouring captured pauses up to `--max-delay`; `--phases 0-5`, `--dry-run`. Reports bulk/control/responses/errors per phase.

Format is a small self-describing record stream (`APLO2`), documented in the extractor's docstring. 214 + 199 lines; both byte-compile; stdlib + `tshark` / `pyusb` only.

### Verified on hardware (Apollo Twin USB DUO, Console 11.7.0 captures)

- Extraction is **byte-identical** to the hand-built sequences that have been running this Twin since 2026-08-24, from two independent captures (2386 events; and 2649 events from a second session with a `--end` cut before a parameter sweep).
- Replay of the full sequence with this tool, today: **940 responses, 0 errors, 118.7 s**, 792 of the responses in the chain-upload phase — same profile as the known-good runs. Card and both PCM devices intact afterwards.
- Not tested on a Solo or Twin X (don't have them). The Solo path in the tree is untouched.

### Things to flag

- `LIVE_PIDS`/`find_device()` is copied from `usb-dsp-init.py` for the same reason as in #71 (tools are run standalone). Same offer: shared module if you'd prefer.
- The replay should not start before ~30 s after the device re-enumerates on a cold DSP — earlier and the chain upload is acknowledged but not acted on (my comment on #62). The docstring says so; the tool doesn't enforce it, since the right number isn't bisected yet.
- The two-stream framing of the bulk protocol (flags byte selects a stream; entries span packets within it) is not needed for replay — packets go out verbatim — so it isn't in these tools. It's in #78.
