### PR TITLE
fix: avoid fragmented DMA allocation failures

### DIFF
--- a/driver/ua_apollo.h
+++ b/driver/ua_apollo.h
@@ -695,11 +695,18 @@ struct ua_audio {
 	struct snd_card *card;
 	struct snd_pcm *pcm;
 
-	/* DMA buffers — 4 MiB coherent per direction */
-	void *play_buf;
-	dma_addr_t play_addr;
-	void *rec_buf;
-	dma_addr_t rec_addr;
+	/*
+	 * DMA buffers — 4 MiB per direction, allocated as
+	 * UA_DMA_SG_ENTRIES separate 4 KiB coherent pages and vmapped
+	 * into one flat CPU range. The hardware SG table maps the pages
+	 * for the device, so no contiguous order-10 block is required.
+	 */
+	void *play_buf;                      /* vmapped CPU view */
+	void *rec_buf;                       /* vmapped CPU view */
+	void *play_cpu[UA_DMA_SG_ENTRIES];   /* per-page coherent CPU addr */
+	void *rec_cpu[UA_DMA_SG_ENTRIES];    /* per-page coherent CPU addr */
+	dma_addr_t play_dmas[UA_DMA_SG_ENTRIES];
+	dma_addr_t rec_dmas[UA_DMA_SG_ENTRIES];
 
 	/* Audio state */
 	bool connected;             /* DSP firmware connection established */

--- a/driver/ua_audio.c
+++ b/driver/ua_audio.c
@@ -18,6 +18,7 @@
 #include <linux/delay.h>
 #include <linux/jiffies.h>
 #include <linux/dma-mapping.h>
+#include <linux/vmalloc.h>
 #include <linux/version.h>
 #include <sound/core.h>
 #include <sound/pcm.h>
@@ -168,47 +169,133 @@ static int ua_audio_alloc_dma(struct ua_device *ua)
 {
 	struct ua_audio *audio = &ua->audio;
 	struct device *dev = &ua->pdev->dev;
+	struct page **pages;
+	unsigned int i;
+	int ret;
 
-	audio->play_buf = dma_alloc_coherent(dev, UA_DMA_BUF_SIZE,
-					     &audio->play_addr, GFP_KERNEL);
-	if (!audio->play_buf)
-		return -ENOMEM;
-
-	audio->rec_buf = dma_alloc_coherent(dev, UA_DMA_BUF_SIZE,
-					    &audio->rec_addr, GFP_KERNEL);
-	if (!audio->rec_buf) {
-		dma_free_coherent(dev, UA_DMA_BUF_SIZE,
-				  audio->play_buf, audio->play_addr);
-		audio->play_buf = NULL;
-		return -ENOMEM;
+	pages = kmalloc_array(UA_DMA_SG_ENTRIES, sizeof(*pages), GFP_KERNEL);
+	if (!pages) {
+		ret = -ENOMEM;
+		goto err_play;
 	}
+
+	/*
+	 * Allocate the 4 MiB ring as UA_DMA_SG_ENTRIES separate 4 KiB
+	 * coherent pages instead of one contiguous order-10 block.
+	 *
+	 * A single 4 MiB dma_alloc_coherent needs a physically contiguous
+	 * order-10 buddy block below 4 GiB (DMA_BIT_MASK(32)); with
+	 * CmaTotal=0, low memory fragments within hours of uptime and
+	 * probe fails with -ENOMEM on every replug (2026-08-29: three
+	 * consecutive -12 failures after the first boot-time connect).
+	 * The hardware walks an SG table of 1024 4 KiB entries, so
+	 * contiguity is not required by the device.
+	 */
+	for (i = 0; i < UA_DMA_SG_ENTRIES; i++) {
+		audio->play_cpu[i] = dma_alloc_coherent(dev,
+						       UA_PCIE_PAGE_SIZE,
+						       &audio->play_dmas[i],
+						       GFP_KERNEL);
+		if (!audio->play_cpu[i]) {
+			ret = -ENOMEM;
+			goto err_play;
+		}
+	}
+
+	for (i = 0; i < UA_DMA_SG_ENTRIES; i++) {
+		audio->rec_cpu[i] = dma_alloc_coherent(dev,
+						      UA_PCIE_PAGE_SIZE,
+						      &audio->rec_dmas[i],
+						      GFP_KERNEL);
+		if (!audio->rec_cpu[i]) {
+			ret = -ENOMEM;
+			goto err_rec;
+		}
+	}
+
+	/*
+	 * One flat CPU view over the scattered pages, so the PCM copy
+	 * callback and the dma_test ioctl keep treating the ring as a
+	 * single 4 MiB buffer.
+	 */
+	for (i = 0; i < UA_DMA_SG_ENTRIES; i++)
+		pages[i] = virt_to_page(audio->play_cpu[i]);
+
+	audio->play_buf = vmap(pages, UA_DMA_SG_ENTRIES, VM_MAP, PAGE_KERNEL);
+	if (!audio->play_buf) {
+		ret = -ENOMEM;
+		goto err_rec;
+	}
+
+	for (i = 0; i < UA_DMA_SG_ENTRIES; i++)
+		pages[i] = virt_to_page(audio->rec_cpu[i]);
+
+	audio->rec_buf = vmap(pages, UA_DMA_SG_ENTRIES, VM_MAP, PAGE_KERNEL);
+	if (!audio->rec_buf) {
+		vunmap(audio->play_buf);
+		audio->play_buf = NULL;
+		ret = -ENOMEM;
+		goto err_rec;
+	}
+
+	kfree(pages);
 
 	memset(audio->play_buf, 0, UA_DMA_BUF_SIZE);
 	memset(audio->rec_buf, 0, UA_DMA_BUF_SIZE);
 
-	dev_info(dev, "DMA buffers: play=%pad rec=%pad (4 MiB each)\n",
-		 &audio->play_addr, &audio->rec_addr);
-	dev_info(dev, "DMA phys:    play=0x%llx rec=0x%llx\n",
-		 (u64)virt_to_phys(audio->play_buf),
-		 (u64)virt_to_phys(audio->rec_buf));
+	dev_info(dev, "DMA buffers: %u pages per direction, vmapped flat (4 MiB each)\n",
+		 UA_DMA_SG_ENTRIES);
+	dev_info(dev, "  play dma[0]=%pad dma[%u]=%pad\n",
+		 &audio->play_dmas[0], UA_DMA_SG_ENTRIES - 1,
+		 &audio->play_dmas[UA_DMA_SG_ENTRIES - 1]);
+	dev_info(dev, "  rec dma[0]=%pad dma[%u]=%pad\n",
+		 &audio->rec_dmas[0], UA_DMA_SG_ENTRIES - 1,
+		 &audio->rec_dmas[UA_DMA_SG_ENTRIES - 1]);
 	return 0;
+
+err_rec:
+	for (i = 0; i < UA_DMA_SG_ENTRIES && audio->rec_cpu[i]; i++) {
+		dma_free_coherent(dev, UA_PCIE_PAGE_SIZE,
+				  audio->rec_cpu[i], audio->rec_dmas[i]);
+		audio->rec_cpu[i] = NULL;
+	}
+err_play:
+	for (i = 0; i < UA_DMA_SG_ENTRIES && audio->play_cpu[i]; i++) {
+		dma_free_coherent(dev, UA_PCIE_PAGE_SIZE,
+				  audio->play_cpu[i], audio->play_dmas[i]);
+		audio->play_cpu[i] = NULL;
+	}
+	kfree(pages);
+	return ret;
 }
 
 static void ua_audio_free_dma(struct ua_device *ua)
 {
 	struct ua_audio *audio = &ua->audio;
 	struct device *dev = &ua->pdev->dev;
+	unsigned int i;
 
+	/* vunmap first — the vmapped view aliases the per-page CPU addrs */
 	if (audio->play_buf) {
-		dma_free_coherent(dev, UA_DMA_BUF_SIZE,
-				  audio->play_buf, audio->play_addr);
+		vunmap(audio->play_buf);
 		audio->play_buf = NULL;
 	}
 
 	if (audio->rec_buf) {
-		dma_free_coherent(dev, UA_DMA_BUF_SIZE,
-				  audio->rec_buf, audio->rec_addr);
+		vunmap(audio->rec_buf);
 		audio->rec_buf = NULL;
+	}
+
+	for (i = 0; i < UA_DMA_SG_ENTRIES && audio->play_cpu[i]; i++) {
+		dma_free_coherent(dev, UA_PCIE_PAGE_SIZE,
+				  audio->play_cpu[i], audio->play_dmas[i]);
+		audio->play_cpu[i] = NULL;
+	}
+
+	for (i = 0; i < UA_DMA_SG_ENTRIES && audio->rec_cpu[i]; i++) {
+		dma_free_coherent(dev, UA_PCIE_PAGE_SIZE,
+				  audio->rec_cpu[i], audio->rec_dmas[i]);
+		audio->rec_cpu[i] = NULL;
 	}
 }
 
@@ -286,25 +373,26 @@ static void ua_audio_program_sg(struct ua_device *ua)
 {
 	struct ua_audio *audio = &ua->audio;
 	unsigned int i;
-	dma_addr_t addr;
 
 	dev_info(&ua->pdev->dev, "=== PROGRAM SG TABLE (%u entries, stride=0x%x) ===\n",
 		 UA_DMA_SG_ENTRIES, UA_PCIE_PAGE_SIZE);
-	dev_info(&ua->pdev->dev, "  play_addr=%pad rec_addr=%pad\n",
-		 &audio->play_addr, &audio->rec_addr);
+	dev_info(&ua->pdev->dev, "  play dma[0]=%pad dma[%u]=%pad\n",
+		 &audio->play_dmas[0], UA_DMA_SG_ENTRIES - 1,
+		 &audio->play_dmas[UA_DMA_SG_ENTRIES - 1]);
+	dev_info(&ua->pdev->dev, "  rec dma[0]=%pad dma[%u]=%pad\n",
+		 &audio->rec_dmas[0], UA_DMA_SG_ENTRIES - 1,
+		 &audio->rec_dmas[UA_DMA_SG_ENTRIES - 1]);
 
 	for (i = 0; i < UA_DMA_SG_ENTRIES; i++) {
-		addr = audio->play_addr + (dma_addr_t)i * UA_PCIE_PAGE_SIZE;
 		ua_write(ua, UA_REG_PLAY_DMA_BASE + i * 8,
-			 lower_32_bits(addr));
+			 lower_32_bits(audio->play_dmas[i]));
 		ua_write(ua, UA_REG_PLAY_DMA_BASE + i * 8 + 4,
-			 upper_32_bits(addr));
+			 upper_32_bits(audio->play_dmas[i]));
 
-		addr = audio->rec_addr + (dma_addr_t)i * UA_PCIE_PAGE_SIZE;
 		ua_write(ua, UA_REG_REC_DMA_BASE + i * 8,
-			 lower_32_bits(addr));
+			 lower_32_bits(audio->rec_dmas[i]));
 		ua_write(ua, UA_REG_REC_DMA_BASE + i * 8 + 4,
-			 upper_32_bits(addr));
+			 upper_32_bits(audio->rec_dmas[i]));
 	}
 
 	/* No doorbell — kext ProgramRegisters writes SG directly without one */
@@ -338,11 +426,12 @@ static void ua_audio_program_sg(struct ua_device *ua)
 	ua_enable_vector(ua, UA_IRQ_VEC_NOTIFICATION);
 
 	dev_info(&ua->pdev->dev, "  SG[0]: play=0x%08x rec=0x%08x\n",
-		 lower_32_bits(audio->play_addr),
-		 lower_32_bits(audio->rec_addr));
-	dev_info(&ua->pdev->dev, "  SG[1023]: play=0x%08x rec=0x%08x\n",
-		 lower_32_bits(audio->play_addr + 1023ULL * UA_PCIE_PAGE_SIZE),
-		 lower_32_bits(audio->rec_addr + 1023ULL * UA_PCIE_PAGE_SIZE));
+		 lower_32_bits(audio->play_dmas[0]),
+		 lower_32_bits(audio->rec_dmas[0]));
+	dev_info(&ua->pdev->dev, "  SG[%u]: play=0x%08x rec=0x%08x\n",
+		 UA_DMA_SG_ENTRIES - 1,
+		 lower_32_bits(audio->play_dmas[UA_DMA_SG_ENTRIES - 1]),
+		 lower_32_bits(audio->rec_dmas[UA_DMA_SG_ENTRIES - 1]));
 }
 
 /*

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -651,6 +651,13 @@ deploy_configs() {
 # ================================================================
 # Step 6: Verify hardware + PipeWire
 # ================================================================
+apollo_driver_bound() {
+    local driver_link="$1"
+
+    [ -L "$driver_link" ] || return 1
+    [ "$(basename "$(readlink -f "$driver_link")")" = "ua_apollo" ]
+}
+
 run_init() {
     header "Hardware Verification"
 
@@ -701,7 +708,19 @@ run_init() {
         ok "Driver already loaded"
     fi
 
-    # Gate 2: Wait for device node (driver probe complete)
+    # Gate 2: Verify the loaded module claimed the Apollo.
+    local apollo_addr driver_link
+    apollo_addr=$(lspci -D -d 1a00: 2>/dev/null | awk 'NR == 1 { print $1 }')
+    driver_link="/sys/bus/pci/devices/$apollo_addr/driver"
+    if ! apollo_driver_bound "$driver_link"; then
+        fail "Driver loaded but not bound to Apollo — check dmesg for probe errors"
+        STEP_STATUS[init]="fail"
+        STEP_DETAIL[init]="module loaded but device unbound"
+        return 1
+    fi
+    ok "Driver bound to Apollo"
+
+    # Gate 3: Wait for device node (driver probe complete)
     info "Waiting for device node..."
     local tries=0
     while [ ! -e /dev/ua_apollo0 ] && [ $tries -lt 50 ]; do
@@ -717,7 +736,7 @@ run_init() {
         return 1
     fi
 
-    # Gate 3: Wait for ACEFACE connect (DSP handshake)
+    # Gate 4: Wait for ACEFACE connect (DSP handshake)
     # Check dmesg (needs sudo) or verify ALSA card appeared (indirect confirmation).
     info "Waiting for DSP handshake..."
     local aceface_ok=0
@@ -740,7 +759,7 @@ run_init() {
         warn "DSP handshake not confirmed after 30s — proceeding cautiously"
     fi
 
-    # Gate 4: Verify ALSA card registered (retry up to 10s)
+    # Gate 5: Verify ALSA card registered (retry up to 10s)
     local alsa_ok=0
     for i in $(seq 1 10); do
         if aplay -l 2>/dev/null | grep -qi apollo; then
@@ -755,7 +774,7 @@ run_init() {
         warn "ALSA card not found — audio may not work"
     fi
 
-    # Gate 5: Verify hardware is responsive (read a register)
+    # Gate 6: Verify hardware is responsive (read a register)
     # Check that BAR0 reads don't return 0xFFFFFFFF
     if dmesg 2>/dev/null | grep -q "device unreachable\|PCIe error detected"; then
         fail "Apollo PCIe link is down — power cycle Apollo and try again"
@@ -765,7 +784,7 @@ run_init() {
     fi
     ok "Hardware responding"
 
-    # Gate 6: Set up PipeWire virtual I/O devices
+    # Gate 7: Set up PipeWire virtual I/O devices
     local pw_user="${SUDO_USER:-$(logname 2>/dev/null || echo "")}"
     local pw_uid
     pw_uid=$(id -u "$pw_user" 2>/dev/null || echo "")
@@ -784,7 +803,7 @@ run_init() {
         sudo -u "$pw_user" HOME="$pw_home" XDG_RUNTIME_DIR="/run/user/$pw_uid" \
             /usr/local/bin/apollo-setup-io 2>&1 || true
 
-        # Gate 7: Verify virtual devices appeared
+        # Gate 8: Verify virtual devices appeared
         sleep 2
         local vdev_count
         vdev_count=$(sudo -u "$pw_user" XDG_RUNTIME_DIR="/run/user/$pw_uid" \

--- a/tests/test-install-module-binding.sh
+++ b/tests/test-install-module-binding.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -uo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Load installer functions without running the installer main routine.
+source <(sed '/^# Main$/q' "$PROJECT_DIR/scripts/install.sh")
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/drivers/ua_apollo"
+ln -s "$tmp_dir/drivers/ua_apollo" "$tmp_dir/bound"
+
+if apollo_driver_bound "$tmp_dir/unbound"; then
+	echo "FAIL: missing driver link accepted as bound"
+	exit 1
+fi
+
+if ! apollo_driver_bound "$tmp_dir/bound"; then
+	echo "FAIL: ua_apollo driver link rejected as unbound"
+	exit 1
+fi
+
+echo "PASS: installer distinguishes bound and unbound modules"


### PR DESCRIPTION
## Summary

* Allocate each 4 MiB audio ring as 1024 coherent pages.
* Program the hardware scatter gather table from the page addresses.
* Make the installer fail immediately when the module loads but does not bind to the Apollo.
* Add a regression test for bound and unbound driver links.

## Reproduction

The existing driver failed after memory fragmentation even though free memory remained:

```text
page allocation failure: order:10
DMA pre-alloc failed: -12
probe with driver ua_apollo failed with error -12
```

The installer then treated the resident module as loaded and waited for a device node that could not appear.

## Validation

The same Apollo Twin X allocated 1024 pages per direction, registered its sound card, and created `/dev/ua_apollo0`.

```text
PASS: installer distinguishes bound and unbound modules
PASS: live Apollo binding accepted
```

Additional checks:

* `make -C driver`
* `bash -n scripts/install.sh tests/test-install-module-binding.sh`
* `git diff --check`

The driver build still reports three warnings already present on `master`. This change does not add a warning.

## Maintainer follow-up (review fixes)

Two commits added on top of the original two, from the review of this PR.

**Driver**

* `dma_alloc_pages()` per ring page instead of `dma_alloc_coherent()` + `virt_to_page()` + `vmap()`. Behind an IOMMU (any VT-d / AMD-Vi host; a Thunderbolt-attached device is forced into a translated domain as `untrusted`) the coherent CPU pointer is a vmalloc remap, so `virt_to_page()` returned garbage and probe failed with `-ENOMEM` on every connect. `dma_alloc_pages()` returns real struct pages, still never needs a contiguous order-10 block, and the PCM copy / silence / dma_test paths now do the DMA-API `dma_sync_single_*` handoffs (no-ops on x86).
* The four 1024-entry arrays are out of `struct ua_audio`: embedding them pushed `devm_kzalloc(ua_device)` to an order-4 costly allocation, the same fragmentation failure class moved one level up. Bookkeeping now lives in two `kvcalloc()`ed buffers per ring.
* `BUILD_BUG_ON` for the `PAGE_SIZE == 4 KiB` SG stride and `entries × page == UA_DMA_BUF_SIZE` couplings the flat view relies on.
* `ua_audio_init()`'s fallback allocation goes through `ua_audio_preinit_dma()`, so a warm-boot retry programs the SG SRAM instead of leaving the FPGA on the previous OS's entries.
* Redundant 8 MiB memset and duplicated `dma[0]/dma[1023]` log lines dropped; an rwsem guards teardown against a PCM copy/silence callback still in flight (`snd_card_disconnect()` does not drain those).

**Installer / test**

* The bind gate matches `1a00:0002` (vendor-only matching also picks up UAD-2 PCIe cards, which this driver binds), fails distinctly when the Apollo has left the bus, names the driver that owns the device when it is not `ua_apollo`, and keeps watching the driver link during the device-node wait so a probe that fails after the gate reports "probe failed" instead of the old 10 s timeout message.
* `install.sh` has a `main()` guard so tests can source it. The sed-based sourcing ran the installer's argument loop against the test's own arguments (`--help` passed with zero assertions, any other flag failed). The test now covers the foreign-driver and empty-address cases, is executable, and runs in CI (`installer-tests` job).

**Not verified on hardware:** no Apollo or Linux build host was available for this follow-up; the driver change is compile-checked by the `driver-build` job. A run on a non-IOMMU host (the reporter's case) and on a VT-d host before merge would be ideal.

The troubleshooting wiki's dmesg table was updated separately for the new `DMA buffers: 1024 pages per direction` line (docs moved to the wiki in #81).
